### PR TITLE
Adds in support for an ingress class name global config

### DIFF
--- a/src/server/services/ingress.ts
+++ b/src/server/services/ingress.ts
@@ -102,7 +102,11 @@ export default class IngressService extends BaseService {
     const { lifecycleDefaults } = await GlobalConfigService.getInstance().getAllConfigs();
     const manifests = configurations.map((configuration) => {
       return yaml.dump(
-        this.generateNginxManifestForConfiguration({ configuration, defaultUUID: lifecycleDefaults?.defaultUUID }),
+        this.generateNginxManifestForConfiguration({
+          configuration,
+          defaultUUID: lifecycleDefaults?.defaultUUID,
+          ingressClassName: lifecycleDefaults?.ingressClassName
+        }),
         {
           skipInvalid: true,
         }
@@ -117,13 +121,17 @@ export default class IngressService extends BaseService {
   /**
    * Generates an nginx manifest for an ingress configuration
    * @param configuration the ingress configuration that describes a deploy object
+   * @param defaultUUID the default UUID from global configuration
+   * @param ingressClassName the ingress class name from global configuration (defaults to 'nginx' if not set)
    */
   private generateNginxManifestForConfiguration = ({
     configuration,
     defaultUUID,
+    ingressClassName,
   }: {
     configuration: IngressConfiguration;
     defaultUUID: string;
+    ingressClassName?: string;
   }) => {
     const annotations = {
       ...configuration.ingressAnnotations,
@@ -143,7 +151,7 @@ export default class IngressService extends BaseService {
       },
       spec: {
         rules: this.generateRulesForManifest(configuration),
-        ingressClassName: 'nginx',
+        ingressClassName: ingressClassName || 'nginx',
       },
     };
   };

--- a/src/server/services/types/globalConfig.ts
+++ b/src/server/services/types/globalConfig.ts
@@ -86,6 +86,7 @@ export type LifecycleDefaults = {
   deployNamespace: string;
   deployCluster: string;
   helmDeployPipeline: string;
+  ingressClassName?: string;
 };
 
 export type PublicChart = {


### PR DESCRIPTION
Addresses:
https://github.com/GoodRxOSS/lifecycle/issues/3

Right now the ingress class name is hard coded to "nginx". This adds in support for an override, so we can customize it depending on what class name is used for the given cluster.
