### PR TITLE
Add grace period to jobs to deter disruption

### DIFF
--- a/src/server/lib/nativeBuild/utils.ts
+++ b/src/server/lib/nativeBuild/utils.ts
@@ -91,6 +91,8 @@ export function createJob(
       template: {
         spec: {
           serviceAccountName: 'runtime-sa',
+          // Resasonable grace period for container builds to avoid overly disruptive terminations.
+          terminationGracePeriodSeconds: 600,
           tolerations: [
             {
               key: 'builder',


### PR DESCRIPTION
Deters job termination from tools like Karpenter, without having to set an explicit disruption budget.