### PR TITLE
update release pipeline to support pre-releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Build & Push Docker Images on ReleaseAdd commentMore actions
+name: Build & Push Docker Images on Release
 
 on:
   release:
@@ -10,19 +10,75 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+
+      - name: Extract release metadata
+        id: meta
+        run: |
+          # Get the tag name
+          VERSION="${GITHUB_REF_NAME}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Check if this is a pre-release
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            
+            # Extract pre-release type (beta, alpha, rc, etc.)
+            if [[ "$VERSION" =~ -([a-zA-Z]+)\. ]]; then
+              PRERELEASE_TYPE="${BASH_REMATCH[1]}"
+              echo "prerelease_type=$PRERELEASE_TYPE" >> $GITHUB_OUTPUT
+            else
+              echo "prerelease_type=beta" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Output for debugging
+          echo "Version: $VERSION"
+          echo "Is Pre-release: ${{ github.event.release.prerelease }}"
+
       - name: Set up QEMU (for multi-arch)
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          TAGS="${{ secrets.DOCKERHUB_USERNAME }}/app:${{ steps.meta.outputs.version }}"
+
+          if [[ "${{ steps.meta.outputs.is_prerelease }}" == "true" ]]; then
+            # For pre-releases, add the pre-release type tag (beta, alpha, rc, etc.)
+            TAGS="$TAGS,${{ secrets.DOCKERHUB_USERNAME }}/app:${{ steps.meta.outputs.prerelease_type }}"
+          else
+            # For stable releases, add the 'latest' tag
+            TAGS="$TAGS,${{ secrets.DOCKERHUB_USERNAME }}/app:latest"
+            
+            # Also add major and major.minor tags for stable releases
+            # e.g., 1.2.3 -> also tag as 1 and 1.2
+            VERSION="${{ steps.meta.outputs.version }}"
+            if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              MAJOR="${BASH_REMATCH[1]}"
+              MINOR="${BASH_REMATCH[2]}"
+              TAGS="$TAGS,${{ secrets.DOCKERHUB_USERNAME }}/app:$MAJOR"
+              TAGS="$TAGS,${{ secrets.DOCKERHUB_USERNAME }}/app:$MAJOR.$MINOR"
+            fi
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          echo "Docker tags: $TAGS"
+
       - name: Build and push lifecycle image
         uses: docker/build-push-action@v4
         with:
@@ -30,9 +86,7 @@ jobs:
           file: Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/app:${{ github.ref_name }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/app:latest
+          tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             PORT=5001
             NODE_ENV=production


### PR DESCRIPTION
Adds support for doing alpha and beta release.
Example:

* tag 0.0.4 -> Docker tags: 0.0.4, latest
* tag 0.0.5-beta.1 -> Docker tags: 0.0.5-beta.1, beta
* tag 0.0.6-alpha.2 -> Docker tags: 0.0.6-alpha.2, alpha