### PR TITLE
feat: configurable labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ helm/environments/**/secrets.yaml
 
 # Claude Code files
 CLAUDE.md
-.specs/
+llm-docs/
+llm-specs/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ coverage
 dist
 
 helm/environments/**/secrets.yaml
+
+# Claude Code files
+CLAUDE.md
+.specs/

--- a/src/server/db/migrations/001_seed.ts
+++ b/src/server/db/migrations/001_seed.ts
@@ -463,6 +463,7 @@ export async function up(knex: Knex): Promise<any> {
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('features', '{"namespace":true}', now(), now(), null, 'Configuration for feature flags controlled from database');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('serviceAccount', '{"name": "default","role":"replace_me"}', now(), now(), null, 'Default IAM role name to be used to annotate service account');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('app_setup', '{"state":"","created":false,"installed":false,"restarted":false,"org":"","url":"","name":""}', now(), now(), null, 'Application setup state');
+    INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('labels', '{"deploy":["lifecycle-deploy!"],"disabled":["lifecycle-disabled!"],"statusComments":["lifecycle-status-comments!"],"defaultStatusComments":true}', now(), now(), null, 'Configurable PR labels for deploy, disabled, and status comments');
   `);
 
   await knex.schema.raw(`

--- a/src/server/models/PullRequest.ts
+++ b/src/server/models/PullRequest.ts
@@ -68,7 +68,7 @@ export default class PullRequest extends Model {
   githubLogin: string;
 
   branchName: string;
-  labels: string[] | string;
+  labels: string[];
   latestCommit: string;
 
   static tableName = 'pull_requests';

--- a/src/server/models/yaml/types.ts
+++ b/src/server/models/yaml/types.ts
@@ -21,7 +21,6 @@ export type LifecycleYamlConfigEnvironment = {
   optionalServices?: YamlService[];
   webhooks?: YamlWebhook[];
   enabledFeatures?: string[];
-  hasGithubStatusComment?: boolean;
 };
 
 export type LifecycleYamlConfigOptions = {

--- a/src/server/services/__tests__/globalConfig.test.ts
+++ b/src/server/services/__tests__/globalConfig.test.ts
@@ -82,6 +82,62 @@ describe('GlobalConfigService', () => {
     });
   });
 
+  describe('getLabels', () => {
+    it('should return labels configuration from global config', async () => {
+      const mockLabelsConfig = {
+        deploy: ['lifecycle-deploy!', 'custom-deploy!'],
+        disabled: ['lifecycle-disabled!', 'no-deploy!'],
+        statusComments: ['lifecycle-status-comments!', 'show-status!'],
+        defaultStatusComments: true,
+      };
+
+      const mockGetAllConfigs = jest.spyOn(service, 'getAllConfigs').mockResolvedValueOnce({
+        labels: mockLabelsConfig,
+      });
+
+      const result = await service.getLabels();
+
+      expect(result).toEqual(mockLabelsConfig);
+      expect(mockGetAllConfigs).toHaveBeenCalled();
+
+      mockGetAllConfigs.mockRestore();
+    });
+
+    it('should return fallback defaults when labels config does not exist', async () => {
+      const mockGetAllConfigs = jest.spyOn(service, 'getAllConfigs').mockResolvedValueOnce({
+        // no labels config
+      });
+
+      const result = await service.getLabels();
+
+      expect(result).toEqual({
+        deploy: ['lifecycle-deploy!'],
+        disabled: ['lifecycle-disabled!'],
+        statusComments: ['lifecycle-status-comments!'],
+        defaultStatusComments: true,
+      });
+      expect(mockGetAllConfigs).toHaveBeenCalled();
+
+      mockGetAllConfigs.mockRestore();
+    });
+
+    it('should return fallback defaults when getAllConfigs throws an error', async () => {
+      const mockGetAllConfigs = jest.spyOn(service, 'getAllConfigs').mockRejectedValueOnce(new Error('DB error'));
+
+      const result = await service.getLabels();
+
+      expect(result).toEqual({
+        deploy: ['lifecycle-deploy!'],
+        disabled: ['lifecycle-disabled!'],
+        statusComments: ['lifecycle-status-comments!'],
+        defaultStatusComments: true,
+      });
+      expect(mockGetAllConfigs).toHaveBeenCalled();
+
+      mockGetAllConfigs.mockRestore();
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -523,7 +523,6 @@ export default class BuildService extends BaseService {
     const env = lifecycleConfig?.environment;
     const enabledFeatures = env?.enabledFeatures || [];
     const githubDeployments = env?.githubDeployments || false;
-    const hasGithubStatusComment = env?.hasGithubStatusComment || false;
     const build =
       (await this.db.models.Build.query()
         .where('pullRequestId', options.pullRequestId)
@@ -539,7 +538,6 @@ export default class BuildService extends BaseService {
         enableFullYaml: this.db.services.Environment.enableFullYamlSupport(environment),
         enabledFeatures: JSON.stringify(enabledFeatures),
         githubDeployments,
-        hasGithubStatusComment,
         namespace: `env-${uuid}`,
       }));
     logger.info(`[BUILD ${build.uuid}] Created build for pull request branch: ${options.repositoryBranchName}`);

--- a/src/server/services/globalConfig.ts
+++ b/src/server/services/globalConfig.ts
@@ -17,7 +17,7 @@
 import { createAppAuth } from '@octokit/auth-app';
 import rootLogger from 'server/lib/logger';
 import BaseService from './_service';
-import { GlobalConfig } from './types/globalConfig';
+import { GlobalConfig, LabelsConfig } from './types/globalConfig';
 import { GITHUB_APP_INSTALLATION_ID, APP_AUTH, APP_ENV } from 'shared/config';
 import { Metrics } from 'server/lib/metrics';
 import { redisClient } from 'server/lib/dependencies';
@@ -108,6 +108,27 @@ export default class GlobalConfigService extends BaseService {
     const { features } = await this.getAllConfigs();
     if (!features) return false;
     return Boolean(features[name]);
+  }
+
+  /**
+   * Retrieves labels configuration from global config with fallback defaults
+   * @returns Promise<LabelsConfig> The labels configuration
+   */
+  async getLabels(): Promise<LabelsConfig> {
+    try {
+      const { labels } = await this.getAllConfigs();
+      if (!labels) throw new Error('Labels configuration not found in global config');
+      return labels;
+    } catch (error) {
+      logger.error('Error retrieving labels configuration, using fallback defaults', error);
+      // Return fallback defaults on error
+      return {
+        deploy: ['lifecycle-deploy!'],
+        disabled: ['lifecycle-disabled!'],
+        statusComments: ['lifecycle-status-comments!'],
+        defaultStatusComments: true,
+      };
+    }
   }
 
   private deserialize(config: unknown): GlobalConfig {

--- a/src/server/services/pullRequest.ts
+++ b/src/server/services/pullRequest.ts
@@ -21,7 +21,7 @@ import { UniqueViolationError } from 'objection';
 import _ from 'lodash';
 import * as github from 'server/lib/github';
 import { JOB_VERSION } from 'shared/config';
-import { Labels } from 'shared/constants';
+import GlobalConfigService from './globalConfig';
 import { redisClient } from 'server/lib/dependencies';
 
 export interface PullRequestOptions {
@@ -106,12 +106,13 @@ export default class PullRequestService extends BaseService {
     try {
       await pullRequest.$fetchGraph('repository');
 
+      const labelsConfig = await GlobalConfigService.getInstance().getLabels();
       const hasLabel = await this.pullRequestHasLabelsAndState(
         pullRequest.pullRequestNumber,
         pullRequest.repository.githubInstallationId,
         pullRequest.repository.fullName.split('/')[0],
         pullRequest.repository.fullName.split('/')[1],
-        [Labels.DEPLOY],
+        labelsConfig.deploy,
         'open'
       );
       return hasLabel;

--- a/src/server/services/types/globalConfig.ts
+++ b/src/server/services/types/globalConfig.ts
@@ -36,6 +36,7 @@ export type GlobalConfig = {
   serviceAccount: RoleSettings;
   features: Record<string, boolean>;
   app_setup: AppSetup;
+  labels: LabelsConfig;
 };
 
 export type AppSetup = {
@@ -134,4 +135,11 @@ export type BuildDefaults = {
 export type ResourceRequirements = {
   requests?: Record<string, string>;
   limits?: Record<string, string>;
+};
+
+export type LabelsConfig = {
+  deploy: string[];
+  disabled: string[];
+  statusComments: string[];
+  defaultStatusComments: boolean;
 };

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -120,7 +120,7 @@ export enum FallbackLabels {
   DEPLOY = 'lifecycle-deploy!',
   DISABLED = 'lifecycle-disabled!',
   DEPLOY_STG = 'lifecycle-stg-deploy!',
-  ENABLE_LIFECYCLE_STATUS_COMMENTS = 'lifecycle-status-comments!',
+  STATUS_COMMENTS = 'lifecycle-status-comments!',
 }
 
 export enum FeatureFlags {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -116,12 +116,11 @@ export enum CommentParser {
   FOOTER = `----EDIT ABOVE THIS LINE----`,
 }
 
-export enum Labels {
+export enum FallbackLabels {
   DEPLOY = 'lifecycle-deploy!',
   DISABLED = 'lifecycle-disabled!',
   DEPLOY_STG = 'lifecycle-stg-deploy!',
   ENABLE_LIFECYCLE_STATUS_COMMENTS = 'lifecycle-status-comments!',
-  PURGE_FASTLY_SERVICE_CACHE = 'lifecycle-cache-purge!',
 }
 
 export enum FeatureFlags {


### PR DESCRIPTION
## What
- removes fastly purge cache label
- uses config to set default labels to deploy, destroy and status comment
- config to enable status comments by default. eg orgs with no UI

## Testing
```
auto_deploy:
- create PR, add label ✅
- close PR, remove label ✅
- default status comment = true, add status comment ✅
- default status comment = false, no status comment ✅
- default status comment = false, no status comment, add custom label to get status comment ✅
---


non auto deploy:
- create PR, add label ✅
- close PR, remove label ✅
- default status comment = true, add status comment ✅
- default status comment = false, no status comment ✅
- default status comment = false, no status comment, add custom label to get status comment ✅
---
- disabled label with deploy ✅
- disable label removing deploy ✅

missing config for labels
- create PR, add label ⏳, deploy PR ✅
- close PR, remove label ⏳ ✅
```