### PR TITLE
fix: temp fix for job name creation

### DIFF
--- a/src/server/lib/kubernetesApply/applyManifest.ts
+++ b/src/server/lib/kubernetesApply/applyManifest.ts
@@ -36,7 +36,7 @@ export async function createKubernetesApplyJob({
   const kc = new k8s.KubeConfig();
   kc.loadFromDefault();
   const batchApi = kc.makeApiClient(k8s.BatchV1Api);
-  const shortSha = deploy.sha?.substring(0, 7) || '';
+  const shortSha = deploy.sha?.substring(0, 7) || 'unknown';
   const jobName = `${deploy.uuid}-deploy-${jobId}-${shortSha}`.substring(0, 63);
   const serviceName = deploy.deployable?.name || deploy.service?.name || '';
 


### PR DESCRIPTION
### What
Currently we cannot edit the job name here without updating the monitoring job name templates.  for now as a quick fix reverting this

we should DRY the job name creation to avoid this i guess. will follow up