### PR TITLE
use the secret name from the env var to be configurable

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -44,6 +44,8 @@ module.exports = {
     PINO_PRETTY: process.env.PINO_PRETTY,
     ENVIRONMENT: process.env.ENVIRONMENT,
     APP_HOST: process.env.APP_HOST,
+    SECRET_BOOTSTRAP_NAME: process.env.SECRET_BOOTSTRAP_NAME,
+    SECRET_COMMON_NAME: process.env.SECRET_COMMON_NAME,
   },
   typescript: {
     ignoreBuildErrors: true,

--- a/scripts/k8-start.sh
+++ b/scripts/k8-start.sh
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -e
 
 cd /app
@@ -28,6 +27,8 @@ required_vars=(
   GITHUB_PRIVATE_KEY
   GITHUB_CLIENT_SECRET
   GITHUB_WEBHOOK_SECRET
+  SECRET_BOOTSTRAP_NAME
+  APP_HOST
 )
 
 missing=()

--- a/src/pages/api/v1/setup/callback.ts
+++ b/src/pages/api/v1/setup/callback.ts
@@ -18,6 +18,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateSecret, getCurrentNamespaceFromFile } from 'server/lib/kubernetes';
 import logger from 'server/lib/logger';
 import GlobalConfigService from 'server/services/globalConfig';
+import { SECRET_BOOTSTRAP_NAME } from 'shared/config';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -64,7 +65,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const namespace = getCurrentNamespaceFromFile();
 
     await updateSecret(
-      'app-secrets',
+      SECRET_BOOTSTRAP_NAME,
       {
         GITHUB_APP_ID: id,
         GITHUB_CLIENT_ID: client_id,

--- a/src/pages/api/v1/setup/installed.ts
+++ b/src/pages/api/v1/setup/installed.ts
@@ -18,6 +18,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateSecret, getCurrentNamespaceFromFile } from 'server/lib/kubernetes';
 import logger from 'server/lib/logger';
 import GlobalConfigService from 'server/services/globalConfig';
+import { SECRET_BOOTSTRAP_NAME } from 'shared/config';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { installation_id, setup_action } = req.query;
@@ -50,7 +51,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   logger.info(`Successfully recorded installation ID: ${installation_id}`);
   const namespace = getCurrentNamespaceFromFile();
   await updateSecret(
-    'app-secrets',
+    SECRET_BOOTSTRAP_NAME,
     {
       GITHUB_APP_INSTALLATION_ID: installation_id as string,
     },

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -107,3 +107,6 @@ export const DD_ENVS = {
 };
 export const ENVIRONMENT = getServerRuntimeConfig('ENVIRONMENT', 'production');
 export const APP_HOST = getServerRuntimeConfig('APP_HOST', 'http://localhost:5001');
+
+export const SECRET_BOOTSTRAP_NAME = getServerRuntimeConfig('SECRET_BOOTSTRAP_NAME');
+export const SECRET_COMMON_NAME = getServerRuntimeConfig('SECRET_COMMON_NAME');

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -108,5 +108,5 @@ export const DD_ENVS = {
 export const ENVIRONMENT = getServerRuntimeConfig('ENVIRONMENT', 'production');
 export const APP_HOST = getServerRuntimeConfig('APP_HOST', 'http://localhost:5001');
 
-export const SECRET_BOOTSTRAP_NAME = getServerRuntimeConfig('SECRET_BOOTSTRAP_NAME');
-export const SECRET_COMMON_NAME = getServerRuntimeConfig('SECRET_COMMON_NAME');
+export const SECRET_BOOTSTRAP_NAME = getServerRuntimeConfig('SECRET_BOOTSTRAP_NAME', 'lifecycle-app-secrets');
+export const SECRET_COMMON_NAME = getServerRuntimeConfig('SECRET_COMMON_NAME', 'lifecycle-common-secrets');


### PR DESCRIPTION
## Why
With updated helm chart, we want the secret name to be configurable.  the chart will pass the names as env var `SECRET_BOOTSTRAP_NAME`