### PR TITLE
feat: flag for mission control comments

### DIFF
--- a/src/server/db/migrations/001_seed.ts
+++ b/src/server/db/migrations/001_seed.ts
@@ -463,7 +463,7 @@ export async function up(knex: Knex): Promise<any> {
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('features', '{"namespace":true}', now(), now(), null, 'Configuration for feature flags controlled from database');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('serviceAccount', '{"name": "default","role":"replace_me"}', now(), now(), null, 'Default IAM role name to be used to annotate service account');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('app_setup', '{"state":"","created":false,"installed":false,"restarted":false,"org":"","url":"","name":""}', now(), now(), null, 'Application setup state');
-    INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('labels', '{"deploy":["lifecycle-deploy!"],"disabled":["lifecycle-disabled!"],"statusComments":["lifecycle-status-comments!"],"defaultStatusComments":true}', now(), now(), null, 'Configurable PR labels for deploy, disabled, and status comments');
+    INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('labels', '{"deploy":["lifecycle-deploy!"],"disabled":["lifecycle-disabled!"],"statusComments":["lifecycle-status-comments!"],"defaultStatusComments":true,"defaultControlComments":true}', now(), now(), null, 'Configurable PR labels for deploy, disabled, and status comments');
   `);
 
   await knex.schema.raw(`

--- a/src/server/lib/utils.ts
+++ b/src/server/lib/utils.ts
@@ -256,3 +256,17 @@ export const isDefaultStatusCommentsEnabled = async (): Promise<boolean> => {
   const labelsConfig = await GlobalConfigService.getInstance().getLabels();
   return labelsConfig.defaultStatusComments ?? true;
 };
+
+/**
+ * Check if control comments should be enabled
+ * @returns Promise<boolean> True if control comments are enabled (defaults to true if not configured)
+ */
+export const isControlCommentsEnabled = async (): Promise<boolean> => {
+  try {
+    const labelsConfig = await GlobalConfigService.getInstance().getLabels();
+    return labelsConfig.defaultControlComments ?? true;
+  } catch (error) {
+    initialLogger.warn('[isControlCommentsEnabled] Error retrieving config, defaulting to true', error);
+    return true;
+  }
+};

--- a/src/server/services/__tests__/globalConfig.test.ts
+++ b/src/server/services/__tests__/globalConfig.test.ts
@@ -89,6 +89,7 @@ describe('GlobalConfigService', () => {
         disabled: ['lifecycle-disabled!', 'no-deploy!'],
         statusComments: ['lifecycle-status-comments!', 'show-status!'],
         defaultStatusComments: true,
+        defaultControlComments: true,
       };
 
       const mockGetAllConfigs = jest.spyOn(service, 'getAllConfigs').mockResolvedValueOnce({
@@ -115,6 +116,7 @@ describe('GlobalConfigService', () => {
         disabled: ['lifecycle-disabled!'],
         statusComments: ['lifecycle-status-comments!'],
         defaultStatusComments: true,
+        defaultControlComments: true,
       });
       expect(mockGetAllConfigs).toHaveBeenCalled();
 
@@ -131,6 +133,7 @@ describe('GlobalConfigService', () => {
         disabled: ['lifecycle-disabled!'],
         statusComments: ['lifecycle-status-comments!'],
         defaultStatusComments: true,
+        defaultControlComments: true,
       });
       expect(mockGetAllConfigs).toHaveBeenCalled();
 

--- a/src/server/services/globalConfig.ts
+++ b/src/server/services/globalConfig.ts
@@ -127,6 +127,7 @@ export default class GlobalConfigService extends BaseService {
         disabled: ['lifecycle-disabled!'],
         statusComments: ['lifecycle-status-comments!'],
         defaultStatusComments: true,
+        defaultControlComments: true,
       };
     }
   }

--- a/src/server/services/types/globalConfig.ts
+++ b/src/server/services/types/globalConfig.ts
@@ -142,4 +142,5 @@ export type LabelsConfig = {
   disabled: string[];
   statusComments: string[];
   defaultStatusComments: boolean;
+  defaultControlComments: boolean;
 };


### PR DESCRIPTION
### What
Adds a flag to control default comment from Lifecycle - `defaultControlComments`

By default set to `true`, will create the mission control comment in the pull request.  When set to `false`, stops posting mission control comments to the PR

Useful when testing new versions of Lifecycle in parallel with other tools

