### PR TITLE
feat: envLens attribute to control 0-banner annotation

### DIFF
--- a/docs/schema/yaml/1.0.0.yaml
+++ b/docs/schema/yaml/1.0.0.yaml
@@ -177,6 +177,8 @@ services:
         builder:
           # @param services.helm.docker.builder.engine
           engine: ''
+      # @param services.helm.envLens
+      envLens: false
     # @param services.codefresh
     codefresh:
       # @param services.codefresh.repository (required)

--- a/src/server/lib/jsonschema/schemas/1.0.0.json
+++ b/src/server/lib/jsonschema/schemas/1.0.0.json
@@ -349,6 +349,9 @@
                   "defaultTag",
                   "app"
                 ]
+              },
+              "envLens": {
+                "type": "boolean"
               }
             },
             "required": [

--- a/src/server/lib/nativeHelm/helm.ts
+++ b/src/server/lib/nativeHelm/helm.ts
@@ -268,10 +268,9 @@ export async function deployNativeHelm(deploy: Deploy): Promise<void> {
   }
 
   const { helm } = deployable;
-  const grpc = helm?.grpc;
 
   try {
-    if (!grpc) {
+    if (helm?.envLens) {
       await patchIngress(deploy.uuid, ingressBannerSnippet(deploy), build.namespace);
     }
   } catch (error) {
@@ -320,10 +319,9 @@ async function deployCodefreshHelm(deploy: Deploy, deployService: DeployService,
   await checkPipelineStatus(deployPipelineId)();
 
   const { helm } = deployable;
-  const grpc = helm?.grpc;
 
   try {
-    if (!grpc) {
+    if (helm?.envLens) {
       await patchIngress(deploy.uuid, ingressBannerSnippet(deploy), build.namespace);
     }
   } catch (error) {

--- a/src/server/lib/yamlSchemas/schema_1_0_0/schema_1_0_0.ts
+++ b/src/server/lib/yamlSchemas/schema_1_0_0/schema_1_0_0.ts
@@ -119,6 +119,7 @@ const schema_1_0_0 = {
                 },
                 required: ['name'],
               },
+              envLens: { type: 'boolean' },
               grpc: { type: 'boolean' },
               disableIngressHost: { type: 'boolean' },
               overrideDefaultIpWhitelist: { type: 'boolean' },

--- a/src/server/models/yaml/YamlService.ts
+++ b/src/server/models/yaml/YamlService.ts
@@ -195,6 +195,7 @@ export interface Helm {
   readonly overrideDefaultIpWhitelist?: boolean;
   readonly type?: string;
   readonly builder?: Builder;
+  readonly envLens?: boolean;
   readonly deploymentMethod?: 'native' | 'ci';
   readonly nativeHelm?: NativeHelmConfig;
   readonly envMapping?: {


### PR DESCRIPTION
## What
adds `envLens` attribute to control `0-banner` annotation to be injected in the ingress. this way its explicitly setup and avoid overloading the nginx.conf for the controller if there are several hundred deploys