### PR TITLE
update to use bitnamilegacy repo

### DIFF
--- a/src/server/lib/kubernetesApply/applyManifest.ts
+++ b/src/server/lib/kubernetesApply/applyManifest.ts
@@ -82,7 +82,7 @@ export async function createKubernetesApplyJob({
           containers: [
             {
               name: 'kubectl-apply',
-              image: 'bitnami/kubectl:1.30',
+              image: 'bitnamilegacy/kubectl:1.30',
               command: ['/bin/bash', '-c'],
               args: [
                 `


### PR DESCRIPTION
### What 
patching this for now, if bitnami removes tags from legacy repo this will break. if it does, move away from bitnami images or make this configurable

refer: https://github.com/bitnami/charts/issues/35164