### PR TITLE
fix: do not override cache registry

### DIFF
--- a/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
+++ b/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
@@ -155,7 +155,10 @@ describe('buildkitBuild', () => {
     // Check custom endpoint is used
     expect(fullCommand).toContain('value: "tcp://buildkit-custom.svc.cluster.local:1234"');
 
-    expect(fullCommand).toContain('ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo:cache');
+    // Check cache uses local distribution registry with service name to avoid collisions
+    expect(fullCommand).toContain(
+      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service:cache'
+    );
 
     // Check custom resources are applied
     expect(fullCommand).toContain('cpu: "1"');

--- a/src/server/lib/nativeBuild/engines.ts
+++ b/src/server/lib/nativeBuild/engines.ts
@@ -172,6 +172,18 @@ buildctl ${buildctlArgs.join(' \\\n  ')}
   },
 };
 
+/**
+ * Appends service name to cache reference for non-ECR registries to avoid cache collisions
+ * @param cacheRef - Cache reference (e.g., 'registry/repo:cache' or 'registry/repo/cache')
+ * @param serviceName - Service name to append (e.g., 'psp-web')
+ * @returns Modified cache reference with service name (e.g., 'registry/repo/psp-web:cache')
+ */
+function appendServiceNameToCacheRef(cacheRef: string, serviceName: string): string {
+  // Insert service name before the cache suffix (supports :cache and /cache)
+  const suffix = cacheRef.includes(':cache') ? ':cache' : '/cache';
+  return cacheRef.replace(suffix, `/${serviceName}${suffix}`);
+}
+
 function createBuildContainer(
   name: string,
   engine: BuildEngine,
@@ -309,7 +321,12 @@ export async function buildWithEngine(
   }
 
   const containers = [];
-  const cacheRef = engine.getCacheRef(cacheRegistry, options.ecrRepo);
+  let cacheRef = engine.getCacheRef(cacheRegistry, options.ecrRepo);
+
+  // For non-ECR registries (like local distribution), append service name to avoid cache collisions
+  if (cacheRegistry && !cacheRegistry.includes('ecr') && !cacheRef.includes(`/${serviceName}`)) {
+    cacheRef = appendServiceNameToCacheRef(cacheRef, serviceName);
+  }
 
   const mainDestination = `${options.ecrDomain}/${options.ecrRepo}:${options.tag}`;
   containers.push(


### PR DESCRIPTION
## What
use cache registry with buildkit if setup 