### PR TITLE
Add flag to enable auth on v2 apis

### DIFF
--- a/src/server/middlewares/auth.ts
+++ b/src/server/middlewares/auth.ts
@@ -26,6 +26,10 @@ export const authMiddleware: Middleware = async (request, next) => {
     return next(request);
   }
 
+  if (process.env.ENABLE_AUTH !== 'true') {
+    return next(request);
+  }
+
   const authResult = await verifyAuth(request);
 
   if (!authResult.success) {


### PR DESCRIPTION
- Auth is now disabled by default for v2 APIs
- Set ENABLE_AUTH=true to enable authentication