### PR TITLE
feat(github): Update GitHub App permissions to support Keycloak user linking

### DIFF
--- a/src/pages/api/v1/setup/index.ts
+++ b/src/pages/api/v1/setup/index.ts
@@ -81,6 +81,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       metadata: 'read',
       pull_requests: 'write',
       statuses: 'read',
+      emails: 'read',
     },
     default_events: [
       'issues',


### PR DESCRIPTION
## Summary
This PR updates the GitHub App manifest (`default_permissions`) to include `emails: 'read'`.

## Context
We are implementing Keycloak integration to manage user identities. To successfully link a GitHub user with a Keycloak user, we need access to the user's email address (including private ones).

## Changes
- Added `emails: 'read'` to the `default_permissions` object in the manifest configuration.

## Impact
When the app is re-installed or updated, users will be prompted to grant access to their email addresses.