### PR TITLE
fix(config): provide default values for GitHub App variables

### DIFF
--- a/scripts/k8-start.sh
+++ b/scripts/k8-start.sh
@@ -18,14 +18,6 @@ set -e
 cd /app
 
 # check and error if required env vars are not set
-required_vars=(
-  GITHUB_APP_ID
-  GITHUB_CLIENT_ID
-  GITHUB_APP_INSTALLATION_ID
-  GITHUB_PRIVATE_KEY
-  GITHUB_CLIENT_SECRET
-  GITHUB_WEBHOOK_SECRET
-)
 
 db_configured=false
 if [ -n "$APP_DB_HOST" ] && [ -n "$APP_DB_USER" ] && [ -n "$APP_DB_PASSWORD" ] && [ -n "$APP_DB_NAME" ]; then
@@ -52,12 +44,6 @@ fi
 if [ "$redis_configured" = false ]; then
   missing+=("REDIS_URL or APP_REDIS_* variables")
 fi
-
-for v in "${required_vars[@]}"; do
-  if [ -z "${!v}" ]; then
-    missing+=("$v")
-  fi
-done
 
 if [ ${#missing[@]} -ne 0 ]; then
   echo >&2

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -68,9 +68,9 @@ export const LIFECYCLE_UI_HOSTHAME_WITH_SCHEME = getServerRuntimeConfig(
   'REPLACE_ME_WITH_UI_URL',
 );
 
-export const GITHUB_APP_ID = getServerRuntimeConfig('GITHUB_APP_ID');
-export const GITHUB_CLIENT_ID = getServerRuntimeConfig('GITHUB_CLIENT_ID');
-export const GITHUB_CLIENT_SECRET = getServerRuntimeConfig('GITHUB_CLIENT_SECRET');
+export const GITHUB_APP_ID = getServerRuntimeConfig('GITHUB_APP_ID', 'YOUR_VALUE_HERE');
+export const GITHUB_CLIENT_ID = getServerRuntimeConfig('GITHUB_CLIENT_ID', 'YOUR_VALUE_HERE');
+export const GITHUB_CLIENT_SECRET = getServerRuntimeConfig('GITHUB_CLIENT_SECRET', 'YOUR_VALUE_HERE');
 
 export const LIFECYCLE_MODE = getServerRuntimeConfig('LIFECYCLE_MODE');
 
@@ -84,10 +84,10 @@ export const APP_REDIS_PORT = getServerRuntimeConfig('APP_REDIS_PORT', 6379);
 export const APP_REDIS_PASSWORD = getServerRuntimeConfig('APP_REDIS_PASSWORD', '');
 export const APP_REDIS_TLS = getServerRuntimeConfig('APP_REDIS_TLS', 'false');
 
-export const GITHUB_PRIVATE_KEY = getServerRuntimeConfig('GITHUB_PRIVATE_KEY')
+export const GITHUB_PRIVATE_KEY = getServerRuntimeConfig('GITHUB_PRIVATE_KEY', 'YOUR_VALUE_HERE')
   .replace(/\\n/g, '\n')
   .replace(/\\k/g, '\n');
-export const GITHUB_WEBHOOK_SECRET = getServerRuntimeConfig('GITHUB_WEBHOOK_SECRET');
+export const GITHUB_WEBHOOK_SECRET = getServerRuntimeConfig('GITHUB_WEBHOOK_SECRET', 'YOUR_VALUE_HERE');
 
 export const JOB_VERSION = getServerRuntimeConfig('JOB_VERSION', 'default');
 
@@ -121,7 +121,7 @@ export const QUEUE_NAMES = {
   LABEL: `label_${JOB_VERSION}`,
 } as const;
 
-export const GITHUB_APP_INSTALLATION_ID = getServerRuntimeConfig('GITHUB_APP_INSTALLATION_ID');
+export const GITHUB_APP_INSTALLATION_ID = getServerRuntimeConfig('GITHUB_APP_INSTALLATION_ID', 'YOUR_VALUE_HERE');
 
 export const GITHUB_APP_AUTH_CALLBACK = getServerRuntimeConfig(
   'GITHUB_APP_AUTH_CALLBACK',


### PR DESCRIPTION
## Description

This PR updates the server runtime configuration by adding default values to GitHub-related constants. This prevents potential issues when environment variables are missing during the initial setup or in certain environments.

## Changes

* Added default placeholders for:
* `GITHUB_APP_ID`
* `GITHUB_APP_INSTALLATION_ID`
* `GITHUB_CLIENT_ID`
* `GITHUB_CLIENT_SECRET`
* `GITHUB_PRIVATE_KEY`
* `GITHUB_WEBHOOK_SECRET`

### 🧪 Verification & Testing

The implementation has been successfully verified in a real-world scenario using the following alpha release:

* **Release Tag:** [v0.1.10-alpha.2](https://github.com/GoodRxOSS/lifecycle/releases/tag/0.1.10-alpha.2)
* **Scope:** End-to-end flow validation and configuration persistence.