### PR TITLE
fix(logger): emit string level names instead of numeric values

### DIFF
--- a/src/server/lib/logger/rootLogger.ts
+++ b/src/server/lib/logger/rootLogger.ts
@@ -57,6 +57,11 @@ let rootLogger = pino({
   level,
   enabled,
   serializers,
+  formatters: {
+    level(label) {
+      return { level: label };
+    },
+  },
   ...(pinoPretty ? transport : {}),
 });
 


### PR DESCRIPTION
## Summary

- Adds a `formatters.level` option to the pino constructor in `rootLogger.ts`
- Pino now emits `"level":"info"` (string) instead of `"level":30` (numeric) in structured log output
- Fixes log severity mapping in Groundcover, which expects string-level labels to correctly classify log entries

## Test plan

- [ ] Deploy to a non-production environment and confirm log entries in Groundcover show human-readable severity labels (`info`, `warn`, `error`, etc.) instead of numeric values
- [ ] Verify no regression in local dev (`pino-pretty` output should be unaffected since `formatters.level` is only applied to the raw pino instance, not the pretty transport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)