### PR TITLE
fix: temporary patch for Fastly service lookup domain

### DIFF
--- a/src/server/lib/fastly.ts
+++ b/src/server/lib/fastly.ts
@@ -33,7 +33,11 @@ class Fastly {
 
   async getFastlyUrl(): Promise<string> {
     const { domainDefaults } = await GlobalConfigService.getInstance().getAllConfigs();
-    return `fastly.${domainDefaults.http}`;
+    // TEMP PATCH:
+    // Fastly services for current env are named under fastly.<base-domain> (without "lifecycle.").
+    // This is an interim compatibility fix for lookup failures and should be reworked when
+    // Fastly naming/configuration is moved to a dedicated integration.
+    return `fastly.${domainDefaults.http.replace(/^lifecycle\./, '')}`;
   }
 
   async getCacheKey(uuid: string, fastlyServiceType = ''): Promise<string> {


### PR DESCRIPTION
## Summary
This PR applies a temporary compatibility patch for Fastly service lookup naming in Lifecycle.

Current lookup logic builds Fastly service names using:
- `fastly.${domainDefaults.http}`

In our environment, `domainDefaults.http` and the fasly urls are different

This mismatch causes lookup failures and prevents Fastly-dependent PR comment actions from rendering (for example the purge checkbox).

## Change
In `src/server/lib/fastly.ts`, `getFastlyUrl()` now uses a temporary normalization:
- ``return `fastly.${domainDefaults.http.replace(/^lifecycle\./, '')}`;``

## Why temporary
This is intentionally a short-term fix to unblock lookup behavior.
Fastly integration should be reworked into a dedicated app/service and driven by explicit Fastly domain/config instead of deriving from `domainDefaults.http`.

Inline comments were added in code to make this temporary status explicit.

## Risk / Impact
- Scope is limited to Fastly lookup/purge/dashboard URL resolution paths.
- No global `domainDefaults.http` behavior was changed.
- Existing behavior for non-`lifecycle.` domains remains unchanged.

## Follow-up
- Move Fastly logic out of this app into dedicated integration service.
- Replace this normalization with explicit Fastly base domain config per environment.
