### PR TITLE
fix(config): change default LOG_LEVEL from debug to info

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -88,7 +88,7 @@ export const GITHUB_WEBHOOK_SECRET = getServerRuntimeConfig('GITHUB_WEBHOOK_SECR
 
 export const JOB_VERSION = getServerRuntimeConfig('JOB_VERSION', 'default');
 
-export const LOG_LEVEL = getServerRuntimeConfig('LOG_LEVEL', 'debug');
+export const LOG_LEVEL = getServerRuntimeConfig('LOG_LEVEL', 'info');
 
 export const FASTLY_TOKEN = getServerRuntimeConfig('FASTLY_TOKEN', 'changeme');
 


### PR DESCRIPTION
## Summary

- The `lifecycle-web` component has no `LOG_LEVEL` env var set in its helm chart, so it falls back to the code-level default in `src/shared/config.ts`.
- That default was `'debug'`, causing verbose debug output in the web component in production.
- The worker component already has `LOG_LEVEL=info` set explicitly; this change aligns the web component's fallback with that value.

## Change

`src/shared/config.ts` line 91: `getServerRuntimeConfig('LOG_LEVEL', 'debug')` → `getServerRuntimeConfig('LOG_LEVEL', 'info')`

## Test plan

- [ ] Deploy `lifecycle-web` to a non-production environment without `LOG_LEVEL` set and confirm logs are at `info` level, not `debug`.
- [ ] Confirm the worker component (which sets `LOG_LEVEL=info` explicitly) is unaffected.
- [ ] No unit tests exist for `config.ts`; the change is a one-line default value correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)