### PR TITLE
Add build-stage RDS jobs

### DIFF
--- a/docs/schema/yaml/1.0.0.yaml
+++ b/docs/schema/yaml/1.0.0.yaml
@@ -699,6 +699,43 @@ services:
       command: ''
       # @param services.auroraRestore.arguments (required)
       arguments: ''
+    # @param services.rds
+    rds:
+      # @param services.rds.type (required)
+      type: ''
+      # @param services.rds.sourceTag (required)
+      sourceTag:
+        # @param services.rds.sourceTag.key
+        key: ''
+        # @param services.rds.sourceTag.value (required)
+        value: ''
+      # @param services.rds.additionalTags
+      additionalTags:
+
+      # @param services.rds.image
+      image: ''
+      # @param services.rds.vpcId
+      vpcId: ''
+      # @param services.rds.accountId
+      accountId: ''
+      # @param services.rds.region
+      region: ''
+      # @param services.rds.securityGroupIds
+      securityGroupIds:
+        # @param services.rds.securityGroupIds[]
+        - ''
+      # @param services.rds.subnetGroupName
+      subnetGroupName: ''
+      # @param services.rds.engine
+      engine: ''
+      # @param services.rds.engineVersion
+      engineVersion: ''
+      # @param services.rds.instanceSize
+      instanceSize: ''
+      # @param services.rds.restoreSize
+      restoreSize: ''
+      # @param services.rds.jobTimeout
+      jobTimeout: 0
     # @param services.configuration
     configuration:
       # @param services.configuration.defaultTag (required)

--- a/src/pages/api/v1/builds/[uuid]/services/[name]/buildLogs.ts
+++ b/src/pages/api/v1/builds/[uuid]/services/[name]/buildLogs.ts
@@ -92,6 +92,14 @@ interface BuildLogsListResponse {
  *                         type: string
  *                         enum: [buildkit, kaniko, unknown]
  *                         description: Build engine used
+ *                       jobKind:
+ *                         type: string
+ *                         enum: [native-build, rds]
+ *                         description: Build-stage job kind
+ *                       rdsType:
+ *                         type: string
+ *                         enum: [aurora, rds]
+ *                         description: RDS subtype for RDS jobs
  *                       podName:
  *                         type: string
  *                         description: Kubernetes pod name associated with the build job

--- a/src/pages/builds/[uuid]/services/[name]/buildLogs.tsx
+++ b/src/pages/builds/[uuid]/services/[name]/buildLogs.tsx
@@ -41,6 +41,8 @@ interface BuildJobInfo {
   completedAt?: string;
   duration?: number;
   engine: 'buildkit' | 'kaniko' | 'unknown';
+  jobKind?: 'native-build' | 'rds';
+  rdsType?: 'aurora' | 'rds';
   error?: string;
   podName?: string;
 }
@@ -278,6 +280,7 @@ export default function BuildLogsList() {
   const getContainerDisplayName = (containerName: string): string => {
     if (containerName === 'git-clone') return 'Clone Repository';
     if (containerName === 'buildkit' || containerName === 'kaniko') return 'Build';
+    if (containerName === 'rds-runner') return 'RDS Runner';
     if (containerName.includes('[init]')) return containerName;
     return containerName;
   };
@@ -296,7 +299,7 @@ export default function BuildLogsList() {
       ) : builds.length === 0 ? (
         <EmptyState
           title="No builds found"
-          description="No build jobs have been created for this service yet."
+          description="No build-stage jobs have been created for this service yet."
         />
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: '600px 1fr', gap: '24px', alignItems: 'stretch', flex: 1, minHeight: 0 }}>
@@ -304,7 +307,7 @@ export default function BuildLogsList() {
             jobs={builds}
             selectedJob={selectedJob}
             onJobSelect={handleJobSelect}
-            title="Build History"
+            title="Build Job History"
             statusTextMap={{ Active: 'Building' }}
           />
 

--- a/src/server/db/migrations/014_add_rds_defaults.ts
+++ b/src/server/db/migrations/014_add_rds_defaults.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2025 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+
+const defaultConfig = {
+  aurora: {
+    image: 'lifecycleoss/rds:latest',
+    vpcId: '',
+    accountId: '',
+    region: 'us-west-2',
+    securityGroupIds: [],
+    subnetGroupName: '',
+    engine: 'aurora-mysql',
+    engineVersion: '8.0.mysql_aurora.3.06.0',
+    sourceTag: {
+      key: 'restore-for',
+    },
+    additionalTags: {},
+    instanceSize: 'db.t3.medium',
+    restoreSize: 'db.t3.small',
+    jobTimeout: 5400,
+  },
+  rds: {
+    image: 'lifecycleoss/rds:latest',
+    vpcId: '',
+    accountId: '',
+    region: 'us-west-2',
+    securityGroupIds: [],
+    subnetGroupName: '',
+    engine: 'mysql',
+    engineVersion: '8.0.33',
+    sourceTag: {
+      key: 'restore-for',
+    },
+    additionalTags: {},
+    instanceSize: 'db.t3.small',
+    restoreSize: 'db.t3.small',
+    jobTimeout: 5400,
+  },
+};
+
+export async function up(knex: Knex): Promise<void> {
+  const existingConfig = await knex('global_config').where('key', 'rdsDefaults').first();
+  if (!existingConfig) {
+    await knex('global_config').insert({
+      key: 'rdsDefaults',
+      config: defaultConfig,
+      description: 'Default configuration for build-stage RDS restore jobs.',
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex('global_config').where('key', 'rdsDefaults').del();
+}

--- a/src/server/lib/deploymentManager/deploymentManager.ts
+++ b/src/server/lib/deploymentManager/deploymentManager.ts
@@ -16,7 +16,7 @@
 
 import { Deploy } from 'server/models';
 import { deployHelm } from '../helm';
-import { DeployStatus, DeployTypes, CLIDeployTypes } from 'shared/constants';
+import { DeployStatus, DeployTypes, CLIDeployTypes, ExternalServiceDeployTypes } from 'shared/constants';
 import { createKubernetesApplyJob, monitorKubernetesJob } from '../kubernetesApply/applyManifest';
 import { nanoid, customAlphabet } from 'nanoid';
 import DeployService from 'server/services/deploy';
@@ -130,7 +130,7 @@ export class DeploymentManager {
   private shouldDeployWithKubernetes(deploy: Deploy): boolean {
     const deployType = deploy.deployable?.type || deploy.service?.type;
     // Note: only the below types have Kubernetes manifests
-    return [DeployTypes.GITHUB, DeployTypes.DOCKER, DeployTypes.AURORA_RESTORE].includes(deployType);
+    return [DeployTypes.GITHUB, DeployTypes.DOCKER, ...Array.from(ExternalServiceDeployTypes)].includes(deployType);
   }
 
   private async deployManifests(deploy: Deploy): Promise<void> {
@@ -180,7 +180,8 @@ export class DeploymentManager {
           runUUID
         );
 
-        const cliDeploy = CLIDeployTypes.has(deploy.deployable.type);
+        const cliDeploy =
+          ExternalServiceDeployTypes.has(deploy.deployable.type) || CLIDeployTypes.has(deploy.deployable.type);
         const isReady = cliDeploy ? true : await waitForDeployPodReady(deploy);
 
         if (isReady) {

--- a/src/server/lib/jsonschema/schemas/1.0.0.json
+++ b/src/server/lib/jsonschema/schemas/1.0.0.json
@@ -1331,6 +1331,80 @@
               "arguments"
             ]
           },
+          "rds": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "aurora",
+                  "rds"
+                ]
+              },
+              "sourceTag": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "value"
+                ]
+              },
+              "additionalTags": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "image": {
+                "type": "string"
+              },
+              "vpcId": {
+                "type": "string"
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "securityGroupIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "subnetGroupName": {
+                "type": "string"
+              },
+              "engine": {
+                "type": "string"
+              },
+              "engineVersion": {
+                "type": "string"
+              },
+              "instanceSize": {
+                "type": "string"
+              },
+              "restoreSize": {
+                "type": "string"
+              },
+              "jobTimeout": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "type",
+              "sourceTag"
+            ]
+          },
           "configuration": {
             "type": "object",
             "additionalProperties": false,

--- a/src/server/lib/kubernetes.ts
+++ b/src/server/lib/kubernetes.ts
@@ -18,7 +18,12 @@ import { getLogger } from './logger';
 import yaml from 'js-yaml';
 import _ from 'lodash';
 import { Build, Deploy, Deployable, Service } from 'server/models';
-import { CLIDeployTypes, KubernetesDeployTypes, MEDIUM_TYPE, DEFAULT_TTL_INACTIVITY_DAYS } from 'shared/constants';
+import {
+  ExternalServiceDeployTypes,
+  KubernetesDeployTypes,
+  MEDIUM_TYPE,
+  DEFAULT_TTL_INACTIVITY_DAYS,
+} from 'shared/constants';
 import { shellPromise } from './shell';
 import { flattenObject, waitUntil } from 'server/lib/utils';
 import { ServiceDiskConfig } from 'server/models/yaml';
@@ -622,7 +627,9 @@ export function generateManifest({
   // External Service only deployment
 
   const cliDeploys = deploys.filter((deploy) => {
-    return build.enableFullYaml ? CLIDeployTypes.has(deploy.deployable.type) : CLIDeployTypes.has(deploy.service.type);
+    return build.enableFullYaml
+      ? ExternalServiceDeployTypes.has(deploy.deployable.type)
+      : ExternalServiceDeployTypes.has(deploy.service.type);
   });
 
   const kubernetesDeploys = deploys.filter((deploy) => {
@@ -1756,7 +1763,7 @@ export function generateDeployManifest({
 
   // ExternalName service for CLI deploys
   // return the ExternalName service if we have a cname
-  if (CLIDeployTypes.has(deploy.deployable?.type)) {
+  if (ExternalServiceDeployTypes.has(deploy.deployable?.type)) {
     const externalHost = deploy.cname;
     if (externalHost) {
       return yaml.dump({

--- a/src/server/lib/kubernetes/getNativeBuildJobs.ts
+++ b/src/server/lib/kubernetes/getNativeBuildJobs.ts
@@ -28,6 +28,8 @@ export interface BuildJobInfo {
   completedAt?: string;
   duration?: number;
   engine: 'buildkit' | 'kaniko' | 'unknown';
+  jobKind?: 'native-build' | 'rds';
+  rdsType?: 'aurora' | 'rds';
   error?: string;
   podName?: string;
   source?: 'live' | 'archived';
@@ -40,17 +42,26 @@ export async function getNativeBuildJobs(serviceName: string, namespace: string)
   const coreV1Api = kc.makeApiClient(k8s.CoreV1Api);
 
   try {
-    const labelSelector = `lc-service=${serviceName},app.kubernetes.io/component=build`;
-    const jobListResponse = await batchV1Api.listNamespacedJob(
-      namespace,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      labelSelector
-    );
+    const [nativeJobListResponse, rdsJobListResponse] = await Promise.all([
+      batchV1Api.listNamespacedJob(
+        namespace,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        `lc-service=${serviceName},app.kubernetes.io/component=build`
+      ),
+      batchV1Api.listNamespacedJob(
+        namespace,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        `lfc/service=${serviceName},lfc/job-kind=rds`
+      ),
+    ]);
 
-    const jobs = jobListResponse.body.items || [];
+    const jobs = [...(nativeJobListResponse.body.items || []), ...(rdsJobListResponse.body.items || [])];
 
     const buildJobs: BuildJobInfo[] = [];
 
@@ -58,9 +69,11 @@ export async function getNativeBuildJobs(serviceName: string, namespace: string)
       const jobName = job.metadata?.name || '';
       const labels = job.metadata?.labels || {};
 
-      const buildUuid = labels['lc-deploy-uuid'] || '';
+      const buildUuid = labels['lfc/build-uuid'] || labels['lc-uuid'] || labels['lc-deploy-uuid'] || '';
       const sha = labels['git-sha'] || '';
       const engine = (labels['builder-engine'] || 'unknown') as BuildJobInfo['engine'];
+      const jobKind = (labels['lfc/job-kind'] || 'native-build') as BuildJobInfo['jobKind'];
+      const rdsType = labels['lfc/rds-type'] as BuildJobInfo['rdsType'];
 
       let status: BuildJobInfo['status'] = 'Pending';
       let error: string | undefined;
@@ -127,6 +140,8 @@ export async function getNativeBuildJobs(serviceName: string, namespace: string)
         completedAt: completedAt ? new Date(completedAt).toISOString() : undefined,
         duration,
         engine,
+        jobKind,
+        rdsType,
         error,
         podName,
         source: 'live',
@@ -164,6 +179,8 @@ export async function getNativeBuildJobs(serviceName: string, namespace: string)
               completedAt: archived.completedAt,
               duration: archived.duration,
               engine: (archived.engine as BuildJobInfo['engine']) || 'unknown',
+              jobKind: archived.jobKind || 'native-build',
+              rdsType: archived.rdsType,
               source: 'archived',
             });
           }

--- a/src/server/lib/kubernetes/jobFactory.ts
+++ b/src/server/lib/kubernetes/jobFactory.ts
@@ -83,7 +83,7 @@ export function createKubernetesJob(config: JobConfig): V1Job {
           labels: {
             'app.kubernetes.io/name': appName,
             'app.kubernetes.io/component': component,
-            ...(labels['lc-service'] && { 'lc-service': labels['lc-service'] }),
+            ...labels,
           },
           ...(Object.keys(podAnnotations).length > 0 && { annotations: podAnnotations }),
         },

--- a/src/server/lib/rds/index.ts
+++ b/src/server/lib/rds/index.ts
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2025 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import yaml from 'js-yaml';
+import { customAlphabet } from 'nanoid';
+import { Build, Deploy } from 'server/models';
+import * as YamlService from 'server/models/yaml';
+import GlobalConfigService from 'server/services/globalConfig';
+import { shellPromise } from 'server/lib/shell';
+import { createKubernetesJob } from 'server/lib/kubernetes/jobFactory';
+import { ensureServiceAccountForJob } from 'server/lib/kubernetes/common/serviceAccount';
+import { waitForJobAndGetLogs } from 'server/lib/nativeBuild/utils';
+import { getLogArchivalService } from 'server/services/logArchival';
+import { RdsDefaultsConfig } from 'server/services/types/globalConfig';
+import { DeployStatus, DeployTypes } from 'shared/constants';
+
+const generateJobId = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 6);
+const RUNNER_COMMAND = `
+set -eu
+printf "%s" "$RDS_JOB_SPEC" > /tmp/rds-job-spec.json
+lifecycle-rds "$RDS_ACTION" --spec /tmp/rds-job-spec.json
+`.trim();
+
+export interface ResolvedRdsJobSpec extends RdsDefaultsConfig {
+  action: 'restore' | 'destroy';
+  type: 'aurora' | 'rds';
+  buildUuid: string;
+  deployUuid: string;
+  serviceName: string;
+  sourceTag: {
+    key: string;
+    value: string;
+  };
+  additionalTags: Record<string, string>;
+}
+
+export interface RdsJobResult {
+  success: boolean;
+  logs: string;
+  jobName: string;
+}
+
+function mergeRdsConfig(defaults: RdsDefaultsConfig, config: YamlService.RdsServiceConfig): RdsDefaultsConfig {
+  return {
+    ...defaults,
+    ...config,
+    sourceTag: {
+      ...defaults.sourceTag,
+      ...config.sourceTag,
+    },
+    additionalTags: {
+      ...(defaults.additionalTags || {}),
+      ...(config.additionalTags || {}),
+    },
+  };
+}
+
+function validateResolvedSpec(spec: ResolvedRdsJobSpec): void {
+  const requiredStringFields: Array<keyof ResolvedRdsJobSpec> = [
+    'image',
+    'vpcId',
+    'accountId',
+    'region',
+    'subnetGroupName',
+    'engine',
+    'engineVersion',
+    'instanceSize',
+    'restoreSize',
+    'serviceName',
+    'buildUuid',
+    'deployUuid',
+  ];
+
+  for (const field of requiredStringFields) {
+    const value = spec[field];
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new Error(`Missing required rds config field: ${field}`);
+    }
+  }
+
+  if (!spec.sourceTag?.key?.trim()) {
+    throw new Error('Missing required rds sourceTag.key');
+  }
+
+  if (!spec.sourceTag?.value?.trim()) {
+    throw new Error('Missing required rds sourceTag.value');
+  }
+
+  if (!spec.securityGroupIds || spec.securityGroupIds.length === 0) {
+    throw new Error('Missing required rds securityGroupIds');
+  }
+}
+
+async function loadRdsConfigForDeploy(deploy: Deploy): Promise<YamlService.RdsServiceConfig> {
+  await deploy.$fetchGraph('[build.pullRequest.repository, deployable.repository]');
+
+  if (!deploy.deployable?.name) {
+    throw new Error('RDS jobs currently require a YAML-backed deployable');
+  }
+
+  const repository = deploy.deployable?.repository || deploy.build?.pullRequest?.repository;
+  const branchName = deploy.deployable?.commentBranchName || deploy.branchName || deploy.deployable?.branchName;
+  const serviceName = deploy.deployable.name;
+
+  if (!repository?.fullName || !branchName) {
+    throw new Error('Unable to resolve repository/branch for rds config lookup');
+  }
+
+  const yamlConfig = await YamlService.fetchLifecycleConfigByRepository(repository, branchName);
+  if (!yamlConfig) {
+    throw new Error(`Unable to fetch lifecycle config for ${repository.fullName}@${branchName}`);
+  }
+
+  const service = YamlService.getDeployingServicesByName(yamlConfig, serviceName);
+  const rdsConfig = service ? YamlService.getRdsConfig(service) : null;
+  if (!rdsConfig) {
+    throw new Error(`Unable to find rds config for service ${serviceName}`);
+  }
+
+  return rdsConfig;
+}
+
+export async function resolveRdsJobSpec(deploy: Deploy, action: 'restore' | 'destroy'): Promise<ResolvedRdsJobSpec> {
+  await deploy.$fetchGraph('[build, deployable]');
+
+  if (!deploy.build?.uuid || !deploy.deployable?.name) {
+    throw new Error('RDS jobs require a deploy with build and deployable context');
+  }
+
+  const rdsConfig = await loadRdsConfigForDeploy(deploy);
+  const globalConfig = await GlobalConfigService.getInstance().getAllConfigs();
+  const defaults = globalConfig.rdsDefaults?.[rdsConfig.type];
+
+  if (!defaults) {
+    throw new Error(`Missing global_config.rdsDefaults.${rdsConfig.type}`);
+  }
+
+  const merged = mergeRdsConfig(defaults, rdsConfig);
+
+  const spec: ResolvedRdsJobSpec = {
+    ...merged,
+    action,
+    type: rdsConfig.type,
+    buildUuid: deploy.build.uuid,
+    deployUuid: deploy.uuid,
+    serviceName: deploy.deployable.name,
+    sourceTag: {
+      key: merged.sourceTag.key,
+      value: merged.sourceTag.value,
+    },
+    additionalTags: merged.additionalTags || {},
+  };
+
+  validateResolvedSpec(spec);
+  return spec;
+}
+
+function createRdsJobName(deploy: Deploy, action: 'restore' | 'destroy'): string {
+  const jobId = generateJobId();
+  const shortSha = deploy.sha?.substring(0, 7) || 'unknown';
+  const phase = action === 'restore' ? 'build' : 'destroy';
+  let jobName = `${deploy.uuid}-${phase}-${jobId}-${shortSha}`.substring(0, 63);
+  if (jobName.endsWith('-')) {
+    jobName = jobName.slice(0, -1);
+  }
+  return jobName;
+}
+
+function buildRdsJobManifest(deploy: Deploy, namespace: string, serviceAccountName: string, spec: ResolvedRdsJobSpec) {
+  const jobName = createRdsJobName(deploy, spec.action);
+  const timeout = spec.jobTimeout || 5400;
+
+  const job = createKubernetesJob({
+    name: jobName,
+    namespace,
+    appName: 'lfc-rds',
+    component: 'build',
+    serviceAccount: serviceAccountName,
+    timeout,
+    labels: {
+      'lfc/service': spec.serviceName,
+      'lfc/deploy-uuid': spec.deployUuid,
+      'lfc/build-uuid': spec.buildUuid,
+      'lfc/job-kind': 'rds',
+      'lfc/rds-type': spec.type,
+      'lfc/action': spec.action,
+    },
+    annotations: {
+      'lfc/source-tag-key': spec.sourceTag.key,
+      'lfc/source-tag-value': spec.sourceTag.value,
+    },
+    containers: [
+      {
+        name: 'rds-runner',
+        image: spec.image,
+        command: ['/bin/sh', '-c'],
+        args: [RUNNER_COMMAND],
+        env: [
+          { name: 'AWS_REGION', value: spec.region },
+          { name: 'RDS_ACTION', value: spec.action },
+          { name: 'RDS_JOB_SPEC', value: JSON.stringify(spec) },
+        ],
+        resources: {
+          requests: { cpu: '100m', memory: '256Mi' },
+          limits: { cpu: '500m', memory: '1Gi' },
+        },
+      },
+    ],
+  });
+
+  return { jobName, manifest: yaml.dump(job, { quotingType: '"', forceQuotes: true }) };
+}
+
+async function archiveRdsJob(
+  deploy: Deploy,
+  spec: ResolvedRdsJobSpec,
+  jobName: string,
+  status: 'Complete' | 'Failed',
+  logs: string,
+  startedAt?: string,
+  completedAt?: string,
+  duration?: number
+) {
+  const globalConfig = await GlobalConfigService.getInstance().getAllConfigs();
+  if (!globalConfig.logArchival?.enabled) return;
+
+  const archivalService = getLogArchivalService();
+  await archivalService.archiveLogs(
+    {
+      jobName,
+      jobType: 'build',
+      jobKind: 'rds',
+      serviceName: spec.serviceName,
+      namespace: deploy.build.namespace,
+      status,
+      sha: deploy.sha || '',
+      buildUuid: deploy.build.uuid,
+      deployUuid: deploy.uuid,
+      rdsType: spec.type,
+      archivedAt: new Date().toISOString(),
+      startedAt,
+      completedAt,
+      duration,
+    },
+    logs
+  );
+}
+
+export async function runRdsJob(deploy: Deploy, action: 'restore' | 'destroy'): Promise<RdsJobResult> {
+  await deploy.$fetchGraph('[build, deployable]');
+
+  if (!deploy.build?.namespace) {
+    throw new Error('Unable to resolve namespace for rds job');
+  }
+
+  const spec = await resolveRdsJobSpec(deploy, action);
+  const namespace = deploy.build.namespace;
+  const serviceAccountName = await ensureServiceAccountForJob(namespace, action === 'restore' ? 'build' : 'deploy');
+  const { jobName, manifest } = buildRdsJobManifest(deploy, namespace, serviceAccountName, spec);
+
+  await shellPromise(`cat <<'EOF' | kubectl apply -f -
+${manifest}
+EOF`);
+
+  try {
+    const result = await waitForJobAndGetLogs(jobName, namespace, spec.jobTimeout || 5400);
+    await archiveRdsJob(
+      deploy,
+      spec,
+      jobName,
+      result.success ? 'Complete' : 'Failed',
+      result.logs,
+      result.startedAt,
+      result.completedAt,
+      result.duration
+    );
+    return {
+      success: result.success,
+      logs: result.logs,
+      jobName,
+    };
+  } catch (error: any) {
+    const logs = `RDS job failed: ${error.message || String(error)}`;
+    await archiveRdsJob(deploy, spec, jobName, 'Failed', logs);
+    return {
+      success: false,
+      logs,
+      jobName,
+    };
+  }
+}
+
+export async function deleteBuild(build: Build): Promise<void> {
+  const deploys = await Deploy.query().where({ buildId: build.id, active: true }).withGraphFetched({
+    deployable: true,
+    build: true,
+  });
+
+  await Promise.all(
+    deploys
+      .filter((deploy) => deploy.deployable?.type === DeployTypes.RDS)
+      .map(async (deploy) => {
+        await deploy.$query().patch({
+          status: DeployStatus.BUILDING,
+          statusMessage: 'Running RDS destroy job',
+        });
+        const result = await runRdsJob(deploy, 'destroy');
+        if (!result.success) {
+          throw new Error(`RDS destroy failed for ${deploy.deployable?.name || deploy.uuid}`);
+        }
+      })
+  );
+}

--- a/src/server/lib/yamlSchemas/schema_1_0_0/schema_1_0_0.ts
+++ b/src/server/lib/yamlSchemas/schema_1_0_0/schema_1_0_0.ts
@@ -198,6 +198,41 @@ const schema_1_0_0 = {
             },
             required: ['command', 'arguments'],
           },
+          rds: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              type: { type: 'string', enum: ['aurora', 'rds'] },
+              sourceTag: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  key: { type: 'string' },
+                  value: { type: 'string' },
+                },
+                required: ['value'],
+              },
+              additionalTags: {
+                type: 'object',
+                additionalProperties: { type: 'string' },
+              },
+              image: { type: 'string' },
+              vpcId: { type: 'string' },
+              accountId: { type: 'string' },
+              region: { type: 'string' },
+              securityGroupIds: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+              subnetGroupName: { type: 'string' },
+              engine: { type: 'string' },
+              engineVersion: { type: 'string' },
+              instanceSize: { type: 'string' },
+              restoreSize: { type: 'string' },
+              jobTimeout: { type: 'number' },
+            },
+            required: ['type', 'sourceTag'],
+          },
           configuration: {
             type: 'object',
             additionalProperties: false,

--- a/src/server/models/config/index.test.ts
+++ b/src/server/models/config/index.test.ts
@@ -98,6 +98,15 @@ describe('Yaml Service', () => {
       auroraRestore:
         command: 'ls'
         arguments: '-arg foobar'
+    - name: 'rdsApp'
+      rds:
+        type: 'aurora'
+        sourceTag:
+          value: 'phm-aurora'
+        engineVersion: '8.0.mysql_aurora.3.08.2'
+        additionalTags:
+          app-short: 'phm'
+          owner: 'pharmacy'
     - name: 'configurationApp'
       configuration:
         defaultTag: 'main'
@@ -151,6 +160,14 @@ describe('Yaml Service', () => {
       const service = YamlService.getDeployingServicesByName(config, 'configurationApp');
 
       expect(YamlService.getDeployType(service)).toEqual(DeployTypes.CONFIGURATION);
+    });
+
+    test('RdsService', () => {
+      const parser = new YamlConfigParser();
+      const config = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      const service = YamlService.getDeployingServicesByName(config, 'rdsApp');
+
+      expect(YamlService.getDeployType(service)).toEqual(DeployTypes.RDS);
     });
   });
 
@@ -287,6 +304,16 @@ describe('Yaml Service', () => {
 
       expect(YamlService.getEnvironmentVariables(service)).toEqual(undefined);
     });
+
+    test('RdsService', () => {
+      const parser = new YamlConfigParser();
+      const config = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      new YamlConfigValidator().validate_1_0_0(config);
+
+      const service = YamlService.getDeployingServicesByName(config, 'rdsApp');
+
+      expect(YamlService.getEnvironmentVariables(service)).toEqual(undefined);
+    });
   });
 
   describe('getInitEnvironmentVariables', () => {
@@ -412,6 +439,16 @@ describe('Yaml Service', () => {
       new YamlConfigValidator().validate_1_0_0(config);
 
       const service = YamlService.getDeployingServicesByName(config, 'configurationApp');
+
+      expect(YamlService.getInitEnvironmentVariables(service)).toEqual(undefined);
+    });
+
+    test('RdsService', () => {
+      const parser = new YamlConfigParser();
+      const config = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      new YamlConfigValidator().validate_1_0_0(config);
+
+      const service = YamlService.getDeployingServicesByName(config, 'rdsApp');
 
       expect(YamlService.getInitEnvironmentVariables(service)).toEqual(undefined);
     });

--- a/src/server/models/config/types.ts
+++ b/src/server/models/config/types.ts
@@ -33,6 +33,26 @@ export interface AuroraRestoreService {
   arguments: string;
 }
 
+export interface RdsService {
+  type: 'aurora' | 'rds';
+  sourceTag: {
+    key?: string;
+    value: string;
+  };
+  additionalTags?: Record<string, string>;
+  image?: string;
+  vpcId?: string;
+  accountId?: string;
+  region?: string;
+  securityGroupIds?: string[];
+  subnetGroupName?: string;
+  engine?: string;
+  engineVersion?: string;
+  instanceSize?: string;
+  restoreSize?: string;
+  jobTimeout?: number;
+}
+
 export interface ConfigurationService {
   defaultTag: string;
   branchName: string;
@@ -106,6 +126,7 @@ export interface Service {
   configuration?: ConfigurationService;
   externalHttp?: ExternalHttpService;
   auroraRestore?: AuroraRestoreService;
+  rds?: RdsService;
 }
 
 export interface Webhook {

--- a/src/server/models/yaml/YamlService.ts
+++ b/src/server/models/yaml/YamlService.ts
@@ -164,6 +164,30 @@ export interface AuroraRestoreServiceConfig extends Service {
   readonly command: string;
   readonly arguments: string;
 }
+
+export interface RdsService extends Service {
+  readonly rds: RdsServiceConfig;
+}
+
+export interface RdsServiceConfig {
+  readonly type: 'aurora' | 'rds';
+  readonly sourceTag: {
+    readonly key?: string;
+    readonly value: string;
+  };
+  readonly additionalTags?: Record<string, string>;
+  readonly image?: string;
+  readonly vpcId?: string;
+  readonly accountId?: string;
+  readonly region?: string;
+  readonly securityGroupIds?: string[];
+  readonly subnetGroupName?: string;
+  readonly engine?: string;
+  readonly engineVersion?: string;
+  readonly instanceSize?: string;
+  readonly restoreSize?: string;
+  readonly jobTimeout?: number;
+}
 export interface ConfigurationService extends Service {
   readonly configuration: {
     readonly defaultTag: string;
@@ -342,6 +366,10 @@ export function isAuroraRestoreService(service: Service): boolean {
   return (service as AuroraRestoreService)?.auroraRestore != null;
 }
 
+export function isRdsService(service: Service): boolean {
+  return (service as RdsService)?.rds != null;
+}
+
 /**
  * Determine if the given Lifecycle Service YAML model is a Aurora Restore Service type. Typescript has no runtime meta data to determine the interface type during runtime.
  * The only solution is looking for the combination of attributes to guess the type. If there is a better way to determine runtime type, Pull Request is very welcome.
@@ -383,6 +411,8 @@ export function getDeployType(service: Service): DeployTypes {
     result = DeployTypes.CONFIGURATION;
   } else if (isAuroraRestoreService(service)) {
     result = DeployTypes.AURORA_RESTORE;
+  } else if (isRdsService(service)) {
+    result = DeployTypes.RDS;
   } else if (isHelmService(service)) {
     result = DeployTypes.HELM;
   }
@@ -680,6 +710,11 @@ export function getAppDockerConfig(
   }
 
   return result;
+}
+
+export function getRdsConfig(service: Service): RdsServiceConfig | undefined {
+  if (getDeployType(service) !== DeployTypes.RDS) return;
+  return (service as RdsService).rds;
 }
 
 /**

--- a/src/server/models/yaml/tests/YamlService.test.ts
+++ b/src/server/models/yaml/tests/YamlService.test.ts
@@ -98,6 +98,15 @@ describe('Yaml Service', () => {
       auroraRestore:
         command: 'ls'
         arguments: '-arg foobar'
+    - name: 'rdsApp'
+      rds:
+        type: 'aurora'
+        sourceTag:
+          value: 'phm-aurora'
+        engineVersion: '8.0.mysql_aurora.3.08.2'
+        additionalTags:
+          app-short: 'phm'
+          owner: 'pharmacy'
     - name: 'configurationApp'
       configuration:
         defaultTag: 'main'
@@ -212,6 +221,24 @@ describe('Yaml Service', () => {
     });
   });
 
+  describe('isRdsService', () => {
+    test('Non-RdsService', () => {
+      const parser = new YamlConfigParser();
+      const config: YamlService.LifecycleConfig = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'githubApp');
+
+      expect(YamlService.isRdsService(service)).toEqual(false);
+    });
+
+    test('RdsService', () => {
+      const parser = new YamlConfigParser();
+      const config: YamlService.LifecycleConfig = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'rdsApp');
+
+      expect(YamlService.isRdsService(service)).toEqual(true);
+    });
+  });
+
   describe('getDeployType', () => {
     test('GithubService', () => {
       const parser = new YamlConfigParser();
@@ -259,6 +286,14 @@ describe('Yaml Service', () => {
       const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'configurationApp');
 
       expect(YamlService.getDeployType(service)).toEqual(DeployTypes.CONFIGURATION);
+    });
+
+    test('RdsService', () => {
+      const parser = new YamlConfigParser();
+      const config: YamlService.LifecycleConfig = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'rdsApp');
+
+      expect(YamlService.getDeployType(service)).toEqual(DeployTypes.RDS);
     });
   });
 
@@ -395,6 +430,16 @@ describe('Yaml Service', () => {
 
       expect(YamlService.getEnvironmentVariables(service)).toEqual(undefined);
     });
+
+    test('RdsService', () => {
+      const parser = new YamlConfigParser();
+      const config: YamlService.LifecycleConfig = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      new YamlConfigValidator().validate_1_0_0(config);
+
+      const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'rdsApp');
+
+      expect(YamlService.getEnvironmentVariables(service)).toEqual(undefined);
+    });
   });
 
   describe('getInitEnvironmentVariables', () => {
@@ -522,6 +567,36 @@ describe('Yaml Service', () => {
       const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'configurationApp');
 
       expect(YamlService.getInitEnvironmentVariables(service)).toEqual(undefined);
+    });
+
+    test('RdsService', () => {
+      const parser = new YamlConfigParser();
+      const config: YamlService.LifecycleConfig = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      new YamlConfigValidator().validate_1_0_0(config);
+
+      const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'rdsApp');
+
+      expect(YamlService.getInitEnvironmentVariables(service)).toEqual(undefined);
+    });
+
+    test('getRdsConfig should return rds config', () => {
+      const parser = new YamlConfigParser();
+      const config: YamlService.LifecycleConfig = parser.parseYamlConfigFromString(lifecycleConfigContent);
+      new YamlConfigValidator().validate_1_0_0(config);
+
+      const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'rdsApp');
+
+      expect(YamlService.getRdsConfig(service)).toEqual({
+        type: 'aurora',
+        sourceTag: {
+          value: 'phm-aurora',
+        },
+        engineVersion: '8.0.mysql_aurora.3.08.2',
+        additionalTags: {
+          'app-short': 'phm',
+          owner: 'pharmacy',
+        },
+      });
     });
 
     test('isAfterBuildPipelineId should return value', () => {

--- a/src/server/services/__tests__/deployable.test.ts
+++ b/src/server/services/__tests__/deployable.test.ts
@@ -394,5 +394,99 @@ describe('Deployable Service', () => {
         helm: undefined,
       });
     });
+
+    test('Generates from Rds Service Type Configuration', async () => {
+      const rdsService: YamlService.RdsService = {
+        name: 'pharmacy-db',
+        rds: {
+          type: 'aurora',
+          sourceTag: {
+            value: 'phm-aurora',
+          },
+          engineVersion: '8.0.mysql_aurora.3.08.2',
+          additionalTags: {
+            'app-short': 'phm',
+            owner: 'pharmacy',
+          },
+        },
+      };
+
+      // @ts-ignore
+      const result: DeployableAttributes = await deployableService.generateAttributesFromYamlConfig(
+        100,
+        'unit-test-12345',
+        '1234567890',
+        'unit-test',
+        rdsService
+      );
+
+      expect(result).toEqual({
+        name: 'pharmacy-db',
+        serviceId: null,
+        type: 'rds',
+        buildUUID: 'unit-test-12345',
+        buildId: 100,
+        repositoryId: '1234567890',
+        branchName: 'unit-test',
+        defaultUUID: lifecycleDefaults.defaultUUID,
+        dockerfilePath: serviceDefaults.dockerfilePath,
+        command: null,
+        arguments: null,
+        env: {},
+        envLens: false,
+        port: undefined,
+        initArguments: null,
+        initCommand: null,
+        initDockerfilePath: null,
+        initEnv: {},
+        dockerImage: undefined,
+        defaultTag: undefined,
+        afterBuildPipelineId: undefined,
+        appShort: undefined,
+        ecr: 'lfc/lifecycle-deployments',
+        builder: {},
+        public: false,
+        capacityType: 'SPOT',
+        cpuLimit: null,
+        cpuRequest: '10m',
+        memoryLimit: null,
+        memoryRequest: '100Mi',
+        readinessFailureThreshold: 30,
+        readinessHttpGetPath: '/__lbheartbeat__',
+        readinessHttpGetPort: 8080,
+        readinessInitialDelaySeconds: 0,
+        readinessPeriodSeconds: 10,
+        readinessSuccessThreshold: 1,
+        readinessTcpSocketPort: 8090,
+        readinessTimeoutSeconds: 1,
+        host: domainDefaults.http,
+        acmARN: 'arn:aws:acm:us-west-2:account-id:certificate/ceritifcate-id',
+        defaultInternalHostname: `pharmacy-db-${lifecycleDefaults.defaultUUID}`,
+        defaultPublicUrl: `pharmacy-db-${lifecycleDefaults.defaultUUID}.${domainDefaults.http}`,
+        ipWhitelist: '{ 70.52.40.40/32,160.72.36.84/32 }',
+        hostPortMapping: {},
+        ingressAnnotations: {},
+        pathPortMapping: {},
+        grpc: false,
+        grpcHost: domainDefaults.grpc,
+        defaultGrpcHost: `pharmacy-db-${lifecycleDefaults.defaultUUID}.${domainDefaults.grpc}`,
+        detatchAfterBuildPipeline: false,
+        deployPipelineId: null,
+        deployTrigger: null,
+        destroyPipelineId: null,
+        destroyTrigger: null,
+        dockerBuildPipelineName: lifecycleDefaults.buildPipeline,
+        runtimeName: '',
+        serviceDisksYaml: null,
+        nodeSelector: null,
+        nodeAffinity: null,
+        active: undefined,
+        defaultBranchName: undefined,
+        dependsOnDeployableName: undefined,
+        kedaScaleToZero: null,
+        deploymentDependsOn: [],
+        helm: undefined,
+      });
+    });
   });
 });

--- a/src/server/services/activityStream.ts
+++ b/src/server/services/activityStream.ts
@@ -29,6 +29,7 @@ import {
   CommentParser,
   DeployTypes,
   CLIDeployTypes,
+  ExternalServiceDeployTypes,
   PullRequestStatus,
 } from 'shared/constants';
 import {
@@ -769,7 +770,12 @@ export default class ActivityStream extends BaseService {
   private isGitHubKubernetesDeployment(deploy: Deploy): boolean {
     if (!deploy.deployable) return false;
     const deployType = deploy.deployable.type;
-    return deployType === DeployTypes.GITHUB || deployType === DeployTypes.DOCKER || CLIDeployTypes.has(deployType);
+    return (
+      deployType === DeployTypes.GITHUB ||
+      deployType === DeployTypes.DOCKER ||
+      ExternalServiceDeployTypes.has(deployType) ||
+      CLIDeployTypes.has(deployType)
+    );
   }
 
   /**
@@ -940,7 +946,7 @@ export default class ActivityStream extends BaseService {
         : serviceName;
 
       if (isSelectedDeployType == null || isSelectedDeployType(deploy, build.enableFullYaml, orgChartName)) {
-        if ([DeployTypes.GITHUB, DeployTypes.HELM].includes(serviceType) && deploy.active) {
+        if ([DeployTypes.GITHUB, DeployTypes.HELM, DeployTypes.RDS].includes(serviceType) && deploy.active) {
           // Show Build Logs link if:
           // 1. It's a Codefresh build and buildLogs URL exists, OR
           // 2. It's a Native Build V2 deployment
@@ -948,7 +954,7 @@ export default class ActivityStream extends BaseService {
           if (deploy.buildLogs) {
             // Keep existing Codefresh build logs URL
             buildLogsColumn = deploy.buildLogs;
-          } else if (this.isNativeBuildDeployment(deploy)) {
+          } else if (this.isNativeBuildDeployment(deploy) || serviceType === DeployTypes.RDS) {
             // Always show Native Build logs link - we query Kubernetes directly
             const actualServiceName = deploy.deployable?.name || serviceName;
             buildLogsColumn = `[Build Logs](${APP_HOST}/builds/${build.uuid}/services/${actualServiceName}/buildLogs)`;

--- a/src/server/services/ai/context/__tests__/contextSummarizer.test.ts
+++ b/src/server/services/ai/context/__tests__/contextSummarizer.test.ts
@@ -157,6 +157,21 @@ services:
       expect(result.text).toContain('(externalHttp)');
     });
 
+    it('detects rds type', () => {
+      const yaml = `
+services:
+  - name: svc
+    rds:
+      type: aurora
+      sourceTag:
+        value: phm-aurora
+`;
+      const result = summarizeLifecycleYaml(yaml);
+      expect(result.text).toContain('(rds)');
+      expect(result.text).toContain('Type: aurora');
+      expect(result.text).toContain('SourceTag: phm-aurora');
+    });
+
     it('prefers helm over codefresh when both present', () => {
       const yaml = `
 services:

--- a/src/server/services/ai/context/contextSummarizer.ts
+++ b/src/server/services/ai/context/contextSummarizer.ts
@@ -29,6 +29,7 @@ const SERVICE_TYPE_KEYS = [
   'docker',
   'externalHttp',
   'auroraRestore',
+  'rds',
   'configuration',
 ] as const;
 
@@ -138,6 +139,12 @@ function extractAuroraRestoreLines(block: Record<string, any>, lines: string[]):
   if (block.arguments) lines.push(`  Arguments: ${block.arguments}`);
 }
 
+function extractRdsLines(block: Record<string, any>, lines: string[]): void {
+  if (block.type) lines.push(`  Type: ${block.type}`);
+  if (block.sourceTag?.value) lines.push(`  SourceTag: ${block.sourceTag.value}`);
+  if (block.engineVersion) lines.push(`  EngineVersion: ${block.engineVersion}`);
+}
+
 function extractConfigurationLines(block: Record<string, any>, lines: string[]): void {
   if (block.defaultTag) lines.push(`  DefaultTag: ${block.defaultTag}`);
   if (block.branchName) lines.push(`  Branch: ${block.branchName}`);
@@ -231,6 +238,9 @@ export function summarizeLifecycleYaml(rawYaml: string): LifecycleYamlSummary {
               break;
             case 'auroraRestore':
               extractAuroraRestoreLines(block, serviceLines);
+              break;
+            case 'rds':
+              extractRdsLines(block, serviceLines);
               break;
             case 'configuration':
               extractConfigurationLines(block, serviceLines);

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -24,7 +24,13 @@ import { customAlphabet, nanoid } from 'nanoid';
 import { BuildEnvironmentVariables } from 'server/lib/buildEnvVariables';
 
 import { Build, Deploy, Environment, Service, BuildServiceOverride } from 'server/models';
-import { BuildStatus, CLIDeployTypes, DeployStatus, DeployTypes } from 'shared/constants';
+import {
+  BuildPhaseInfraDeployTypes,
+  BuildStatus,
+  DeployStatus,
+  DeployTypes,
+  ExternalServiceDeployTypes,
+} from 'shared/constants';
 import { type DeployOptions } from './deploy';
 import DeployService from './deploy';
 import BaseService from './_service';
@@ -46,6 +52,7 @@ import GlobalConfigService from './globalConfig';
 import { paginate, PaginationMetadata, PaginationParams } from 'server/lib/paginate';
 import { getYamlFileContentFromBranch } from 'server/lib/github';
 import WebhookService from './webhook';
+import * as rdsJobs from 'server/lib/rds';
 
 const tracer = Tracer.getInstance();
 tracer.initialize('build-service');
@@ -920,9 +927,12 @@ export default class BuildService extends BaseService {
         await this.updateStatusAndComment(build, BuildStatus.TEARING_DOWN, build.runUUID, true, true).catch((error) => {
           getLogger().warn({ error }, `Build: status update failed status=${BuildStatus.TEARING_DOWN}`);
         });
-        await Promise.all([k8s.deleteBuild(build), cli.deleteBuild(build), uninstallHelmReleases(build)]).catch(
-          (error) => getLogger().error({ error }, 'Build: cleanup failed')
-        );
+        await Promise.all([
+          k8s.deleteBuild(build),
+          cli.deleteBuild(build),
+          rdsJobs.deleteBuild(build),
+          uninstallHelmReleases(build),
+        ]).catch((error) => getLogger().error({ error }, 'Build: cleanup failed'));
 
         await Promise.all(
           build.deploys.map(async (deploy) => {
@@ -1065,7 +1075,7 @@ export default class BuildService extends BaseService {
         return _.every(
           await Promise.all(
             deploys
-              .filter((d) => d.active && CLIDeployTypes.has(d.deployable.type))
+              .filter((d) => d.active && BuildPhaseInfraDeployTypes.has(d.deployable.type))
               .map(async (deploy) => {
                 if (!deploy) {
                   getLogger().debug(`Deploy is undefined in deployCLIServices: deploysLength=${deploys.length}`);
@@ -1085,7 +1095,7 @@ export default class BuildService extends BaseService {
         return _.every(
           await Promise.all(
             deploys
-              .filter((d) => d.active && CLIDeployTypes.has(d.service.type))
+              .filter((d) => d.active && BuildPhaseInfraDeployTypes.has(d.service.type))
               .map(async (deploy) => {
                 if (deploy === undefined) {
                   getLogger().debug(`Deploy is undefined in deployCLIServices: deploysLength=${deploys.length}`);
@@ -1239,7 +1249,7 @@ export default class BuildService extends BaseService {
           if (
             deployType === DeployTypes.GITHUB ||
             deployType === DeployTypes.DOCKER ||
-            CLIDeployTypes.has(deployType)
+            ExternalServiceDeployTypes.has(deployType)
           ) {
             // Generate individual manifest for this deploy
             const manifest = k8s.generateDeployManifest({
@@ -1277,7 +1287,7 @@ export default class BuildService extends BaseService {
           (d) =>
             d.deployable.type === DeployTypes.GITHUB ||
             d.deployable.type === DeployTypes.DOCKER ||
-            CLIDeployTypes.has(d.deployable.type)
+            ExternalServiceDeployTypes.has(d.deployable.type)
         );
 
         if (githubTypeDeploys.length > 0) {
@@ -1321,7 +1331,7 @@ export default class BuildService extends BaseService {
             d.active &&
             (d.service.type === DeployTypes.GITHUB ||
               d.service.type === DeployTypes.DOCKER ||
-              CLIDeployTypes.has(d.service.type))
+              ExternalServiceDeployTypes.has(d.service.type))
         );
         const manifest = k8s.generateManifest({ build, deploys, uuid: build.uuid, namespace, serviceAccountName });
         if (manifest && manifest.replace(/---/g, '').trim().length > 0) {

--- a/src/server/services/deploy.ts
+++ b/src/server/services/deploy.ts
@@ -38,6 +38,7 @@ import { buildWithNative } from 'server/lib/nativeBuild';
 import { constructEcrTag } from 'server/lib/codefresh/utils';
 import { ChartType, determineChartType } from 'server/lib/nativeHelm';
 import { SecretProcessor } from 'server/services/secretProcessor';
+import { runRdsJob } from 'server/lib/rds';
 
 export interface DeployOptions {
   ownerId?: number;
@@ -433,6 +434,78 @@ export default class DeployService extends BaseService {
     );
   }
 
+  async deployRds(deploy: Deploy): Promise<boolean> {
+    return withLogContext(
+      { deployUuid: deploy.uuid, serviceName: deploy.deployable?.name || deploy.service?.name },
+      async () => {
+        try {
+          await deploy.reload();
+          await deploy.$fetchGraph('[build, deployable]');
+
+          if (!deploy.deployable) {
+            getLogger().error('RDS: deployable missing reason=legacyServiceConfigUnsupported');
+            return false;
+          }
+
+          if ((deploy.status === DeployStatus.BUILT || deploy.status === DeployStatus.READY) && deploy.cname) {
+            getLogger().info('RDS: skipped reason=alreadyBuilt');
+            return true;
+          }
+
+          const existingDbEndpoint = await this.findExistingAuroraDatabase(deploy.build.uuid, deploy.deployable.name);
+          if (existingDbEndpoint) {
+            getLogger().info('RDS: skipped reason=exists');
+            await deploy.$query().patch({
+              cname: existingDbEndpoint,
+              status: DeployStatus.BUILT,
+              statusMessage: 'RDS resource already exists',
+            });
+            return true;
+          }
+
+          await deploy.$query().patch({
+            status: DeployStatus.BUILDING,
+            statusMessage: 'Running RDS restore job',
+            runUUID: nanoid(),
+          });
+
+          const result = await runRdsJob(deploy, 'restore');
+          if (!result.success) {
+            await deploy.$query().patch({
+              status: DeployStatus.ERROR,
+              statusMessage: 'RDS restore job failed',
+            });
+            return false;
+          }
+
+          const dbEndpoint = await this.findExistingAuroraDatabase(deploy.build.uuid, deploy.deployable.name);
+          if (!dbEndpoint) {
+            await deploy.$query().patch({
+              status: DeployStatus.ERROR,
+              statusMessage: 'RDS restore completed but endpoint could not be resolved',
+            });
+            return false;
+          }
+
+          await deploy.$query().patch({
+            cname: dbEndpoint,
+            status: DeployStatus.BUILT,
+            statusMessage: 'RDS restore completed',
+          });
+          getLogger().info('RDS: restored');
+          return true;
+        } catch (error) {
+          getLogger().error({ error }, 'RDS: restore failed');
+          await deploy.$query().patch({
+            status: DeployStatus.ERROR,
+            statusMessage: 'RDS restore failed',
+          });
+          return false;
+        }
+      }
+    );
+  }
+
   async deployCodefresh(deploy: Deploy): Promise<boolean> {
     return withLogContext(
       { deployUuid: deploy.uuid, serviceName: deploy.deployable?.name || deploy.service?.name },
@@ -549,16 +622,22 @@ export default class DeployService extends BaseService {
     if (deploy.deployable != null) {
       if (deploy.deployable.type === DeployTypes.AURORA_RESTORE) {
         return this.deployAurora(deploy);
+      } else if (deploy.deployable.type === DeployTypes.RDS) {
+        return this.deployRds(deploy);
       } else if (deploy.deployable.type === DeployTypes.CODEFRESH) {
         return this.deployCodefresh(deploy);
       }
     } else if (deploy.service != null) {
       if (deploy.service.type === DeployTypes.AURORA_RESTORE) {
         return this.deployAurora(deploy);
+      } else if (deploy.service.type === DeployTypes.RDS) {
+        return this.deployRds(deploy);
       } else if (deploy.service.type === DeployTypes.CODEFRESH) {
         return this.deployCodefresh(deploy);
       }
     }
+
+    return false;
   }
 
   /**

--- a/src/server/services/types/globalConfig.ts
+++ b/src/server/services/types/globalConfig.ts
@@ -33,6 +33,7 @@ export type GlobalConfig = {
   orgChart: OrgChart;
   auroraRestoreSettings: DatabaseSettings;
   rdsRestoreSettings: DatabaseSettings;
+  rdsDefaults?: RdsDefaults;
   serviceAccount: RoleSettings;
   features: Record<string, boolean>;
   app_setup: AppSetup;
@@ -69,6 +70,32 @@ export type DatabaseSettings = {
   };
   instanceSize: string;
   restoreSize: string;
+};
+
+export type RdsSourceTag = {
+  key: string;
+  value?: string;
+};
+
+export type RdsDefaultsConfig = {
+  image: string;
+  vpcId: string;
+  accountId: string;
+  region: string;
+  securityGroupIds: string[];
+  subnetGroupName: string;
+  engine: string;
+  engineVersion: string;
+  sourceTag: RdsSourceTag;
+  additionalTags?: Record<string, string>;
+  instanceSize: string;
+  restoreSize: string;
+  jobTimeout?: number;
+};
+
+export type RdsDefaults = {
+  aurora: RdsDefaultsConfig;
+  rds: RdsDefaultsConfig;
 };
 
 export type DomainDefaults = {

--- a/src/server/services/types/logArchival.ts
+++ b/src/server/services/types/logArchival.ts
@@ -17,6 +17,7 @@
 export interface ArchivedJobMetadata {
   jobName: string;
   jobType: 'build' | 'deploy';
+  jobKind?: 'native-build' | 'rds';
   serviceName: string;
   namespace: string;
   status: 'Complete' | 'Failed';
@@ -28,5 +29,6 @@ export interface ArchivedJobMetadata {
   deployUuid?: string;
   buildUuid?: string;
   deploymentType?: 'helm' | 'github';
+  rdsType?: 'aurora' | 'rds';
   archivedAt: string;
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -20,6 +20,7 @@ export enum DeployTypes {
   GITHUB = 'github',
   EXTERNAL_HTTP = 'externalHTTP',
   AURORA_RESTORE = 'aurora-restore',
+  RDS = 'rds',
   CODEFRESH = 'codefresh',
   CONFIGURATION = 'configuration',
   HELM = 'helm',
@@ -30,6 +31,7 @@ export const DEPLOY_TYPES = [
   'github',
   'externalHttp',
   'auroraRestore',
+  'rds',
   'rdsRestore',
   'codefresh',
   'configuration',
@@ -41,6 +43,7 @@ export const DEPLOY_TYPES_DICTIONARY = {
   github: 'github',
   extneralHttp: 'externalHttp',
   auroraRestore: 'auroraRestore',
+  rds: 'rds',
   rdsRestore: 'rds-restore',
   codefresh: 'codefresh',
   configuration: 'configuration',
@@ -50,6 +53,10 @@ export const DEPLOY_TYPES_DICTIONARY = {
 export const HelmDeployTypes = new Set([DeployTypes.HELM]);
 
 export const CLIDeployTypes = new Set([DeployTypes.AURORA_RESTORE, DeployTypes.CODEFRESH]);
+
+export const BuildPhaseInfraDeployTypes = new Set([DeployTypes.AURORA_RESTORE, DeployTypes.CODEFRESH, DeployTypes.RDS]);
+
+export const ExternalServiceDeployTypes = new Set([DeployTypes.AURORA_RESTORE, DeployTypes.RDS]);
 
 export const KubernetesDeployTypes = new Set([DeployTypes.DOCKER, DeployTypes.GITHUB]);
 

--- a/src/shared/openApiSpec.ts
+++ b/src/shared/openApiSpec.ts
@@ -224,6 +224,14 @@ export const openApiSpecificationForV2Api: OAS3Options = {
             engine: {
               $ref: '#/components/schemas/NativeBuildEngine',
             },
+            jobKind: {
+              type: 'string',
+              enum: ['native-build', 'rds'],
+            },
+            rdsType: {
+              type: 'string',
+              enum: ['aurora', 'rds'],
+            },
             podName: {
               type: 'string',
               description: 'Kubernetes pod name associated with the build job',


### PR DESCRIPTION
Summary
- add a new static rds service type with sourceTag and additionalTags
- run RDS restore and destroy as build-stage Kubernetes jobs using the external runner image
- surface RDS jobs in build job history, log streaming, archival, and ExternalName manifest generation

Testing
- DATABASE_URL=postgres://localhost:5432/lifecycle BUILD_MODE=yes pnpm test
- pnpm run ts-check (still fails in unrelated pre-existing files and legacy scripts outside this change)