### PR TITLE
fix: isolate build cache per build-uuid to prevent EOF errors

### DIFF
--- a/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
+++ b/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
@@ -155,7 +155,7 @@ describe('buildkitBuild', () => {
     // Check custom endpoint is used
     expect(fullCommand).toContain('value: "tcp://buildkit-custom.svc.cluster.local:1234"');
 
-    // Check cache uses local distribution registry with service name and deployUuid for isolation
+    // Check cache uses local distribution registry with service name and buildUuid for isolation
     expect(fullCommand).toContain(
       'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service/abc123:cache'
     );
@@ -165,7 +165,7 @@ describe('buildkitBuild', () => {
     expect(fullCommand).toContain('memory: "2Gi"');
   });
 
-  it('includes buildUuid in cache ref for cache isolation', async () => {
+  it('falls back to service-name-only cache ref when buildUuid is not provided', async () => {
     const configWithCache = {
       ...mockGlobalConfig,
       buildDefaults: {
@@ -177,15 +177,17 @@ describe('buildkitBuild', () => {
       getAllConfigs: jest.fn().mockResolvedValue(configWithCache),
     });
 
-    await buildkitBuild(mockDeploy, mockOptions);
+    const optionsWithoutBuildUuid = { ...mockOptions, buildUuid: undefined };
+    await buildkitBuild(mockDeploy, optionsWithoutBuildUuid);
 
     const kubectlCalls = (shellPromise as jest.Mock).mock.calls;
     const applyCall = kubectlCalls.find((call) => call[0].includes('kubectl apply'));
     const fullCommand = applyCall[0];
 
     expect(fullCommand).toContain(
-      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service/abc123:cache'
+      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service:cache'
     );
+    expect(fullCommand).not.toContain('test-service/abc123:cache');
   });
 
   it('handles init dockerfile build', async () => {

--- a/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
+++ b/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
@@ -79,6 +79,7 @@ describe('buildkitBuild', () => {
     branch: 'main',
     namespace: 'env-test-123',
     buildId: '456',
+    buildUuid: 'abc123',
     deployUuid: 'test-service-abc123',
     jobTimeout: 1800,
   };
@@ -156,7 +157,7 @@ describe('buildkitBuild', () => {
 
     // Check cache uses local distribution registry with service name and deployUuid for isolation
     expect(fullCommand).toContain(
-      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service/test-service-abc123:cache'
+      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service/abc123:cache'
     );
 
     // Check custom resources are applied
@@ -164,7 +165,7 @@ describe('buildkitBuild', () => {
     expect(fullCommand).toContain('memory: "2Gi"');
   });
 
-  it('includes deployUuid in cache ref for cache isolation', async () => {
+  it('includes buildUuid in cache ref for cache isolation', async () => {
     const configWithCache = {
       ...mockGlobalConfig,
       buildDefaults: {
@@ -183,7 +184,7 @@ describe('buildkitBuild', () => {
     const fullCommand = applyCall[0];
 
     expect(fullCommand).toContain(
-      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service/test-service-abc123:cache'
+      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service/abc123:cache'
     );
   });
 

--- a/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
+++ b/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
@@ -154,14 +154,37 @@ describe('buildkitBuild', () => {
     // Check custom endpoint is used
     expect(fullCommand).toContain('value: "tcp://buildkit-custom.svc.cluster.local:1234"');
 
-    // Check cache uses local distribution registry with service name to avoid collisions
+    // Check cache uses local distribution registry with service name and deployUuid for isolation
     expect(fullCommand).toContain(
-      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service:cache'
+      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service/test-service-abc123:cache'
     );
 
     // Check custom resources are applied
     expect(fullCommand).toContain('cpu: "1"');
     expect(fullCommand).toContain('memory: "2Gi"');
+  });
+
+  it('includes deployUuid in cache ref for cache isolation', async () => {
+    const configWithCache = {
+      ...mockGlobalConfig,
+      buildDefaults: {
+        ...mockGlobalConfig.buildDefaults,
+        cacheRegistry: 'lifecycle-distribution.lifecycle-app.svc.cluster.local',
+      },
+    };
+    (GlobalConfigService.getInstance as jest.Mock).mockReturnValue({
+      getAllConfigs: jest.fn().mockResolvedValue(configWithCache),
+    });
+
+    await buildkitBuild(mockDeploy, mockOptions);
+
+    const kubectlCalls = (shellPromise as jest.Mock).mock.calls;
+    const applyCall = kubectlCalls.find((call) => call[0].includes('kubectl apply'));
+    const fullCommand = applyCall[0];
+
+    expect(fullCommand).toContain(
+      'ref=lifecycle-distribution.lifecycle-app.svc.cluster.local/test-repo/test-service/test-service-abc123:cache'
+    );
   });
 
   it('handles init dockerfile build', async () => {

--- a/src/server/lib/nativeBuild/engines.ts
+++ b/src/server/lib/nativeBuild/engines.ts
@@ -359,6 +359,7 @@ export async function buildWithEngine(
   const containers = [];
   let cacheRef = engine.getCacheRef(cacheRegistry, options.ecrRepo);
 
+  // Scope cache per service + build-uuid to prevent concurrent PR builds from corrupting shared cache entries
   if (cacheRegistry && !cacheRegistry.includes('ecr') && !cacheRef.includes(`/${serviceName}`)) {
     cacheRef = appendCacheRefSegments(cacheRef, serviceName, options.buildUuid);
   }

--- a/src/server/lib/nativeBuild/engines.ts
+++ b/src/server/lib/nativeBuild/engines.ts
@@ -43,6 +43,7 @@ export interface NativeBuildOptions {
   namespace: string;
   buildId: string;
   deployUuid: string;
+  buildUuid?: string;
   serviceAccount?: string;
   jobTimeout?: number;
   cacheRegistry?: string;
@@ -194,16 +195,10 @@ buildctl ${buildctlArgs.join(' \\\n  ')} $SECRET_BUILD_ARGS
   },
 };
 
-/**
- * Appends service name to cache reference for non-ECR registries to avoid cache collisions
- * @param cacheRef - Cache reference (e.g., 'registry/repo:cache' or 'registry/repo/cache')
- * @param serviceName - Service name to append (e.g., 'psp-web')
- * @returns Modified cache reference with service name (e.g., 'registry/repo/psp-web:cache')
- */
-function appendServiceNameToCacheRef(cacheRef: string, serviceName: string): string {
-  // Insert service name before the cache suffix (supports :cache and /cache)
+function appendCacheRefSegments(cacheRef: string, serviceName: string, buildUuid?: string): string {
   const suffix = cacheRef.includes(':cache') ? ':cache' : '/cache';
-  return cacheRef.replace(suffix, `/${serviceName}${suffix}`);
+  const segments = [serviceName, buildUuid].filter(Boolean).join('/');
+  return cacheRef.replace(suffix, `/${segments}${suffix}`);
 }
 
 function createBuildContainer(
@@ -364,15 +359,8 @@ export async function buildWithEngine(
   const containers = [];
   let cacheRef = engine.getCacheRef(cacheRegistry, options.ecrRepo);
 
-  // For non-ECR registries (like local distribution), append service name to avoid cache collisions
   if (cacheRegistry && !cacheRegistry.includes('ecr') && !cacheRef.includes(`/${serviceName}`)) {
-    cacheRef = appendServiceNameToCacheRef(cacheRef, serviceName);
-  }
-
-  // Append deployUuid to isolate cache per environment/PR and prevent concurrent write corruption
-  if (cacheRegistry && !cacheRegistry.includes('ecr') && options.deployUuid) {
-    const suffix = cacheRef.includes(':cache') ? ':cache' : '/cache';
-    cacheRef = cacheRef.replace(suffix, `/${options.deployUuid}${suffix}`);
+    cacheRef = appendCacheRefSegments(cacheRef, serviceName, options.buildUuid);
   }
 
   const mainDestination = `${options.ecrDomain}/${options.ecrRepo}:${options.tag}`;

--- a/src/server/lib/nativeBuild/engines.ts
+++ b/src/server/lib/nativeBuild/engines.ts
@@ -369,6 +369,12 @@ export async function buildWithEngine(
     cacheRef = appendServiceNameToCacheRef(cacheRef, serviceName);
   }
 
+  // Append deployUuid to isolate cache per environment/PR and prevent concurrent write corruption
+  if (cacheRegistry && !cacheRegistry.includes('ecr') && options.deployUuid) {
+    const suffix = cacheRef.includes(':cache') ? ':cache' : '/cache';
+    cacheRef = cacheRef.replace(suffix, `/${options.deployUuid}${suffix}`);
+  }
+
   const mainDestination = `${options.ecrDomain}/${options.ecrRepo}:${options.tag}`;
   containers.push(
     createBuildContainer(

--- a/src/server/services/deploy.ts
+++ b/src/server/services/deploy.ts
@@ -1105,6 +1105,7 @@ export default class DeployService extends BaseService {
             envVars: filteredEnvVars,
             namespace: deploy.build.namespace,
             buildId: String(deploy.build.id),
+            buildUuid: deploy.build.uuid,
             deployUuid: deploy.uuid,
             cacheRegistry: buildDefaults?.cacheRegistry,
             resources: deployable.builder?.resources,


### PR DESCRIPTION
## Summary

- Appends `buildUuid` (environment identifier, e.g., `dev-0`, `wandering-credit-924200`) to the buildkit cache ref for non-ECR registries (distribution), so each environment/PR gets its own isolated cache entry
- Previously, all builds of the same servic shared a single `:cache` tag, causing concurrent write races that corrupted cache manifests
- This corruption led to ~40 buildkit `unexpected EOF` errors per 2 days across builds

**Before:** `distribution.../repo/service-name:cache` (shared across all PRs)
**After:** `distribution.../repo/service-name/build-uuid:cache` (isolated per environment)

## Changes

- Add `buildUuid` to `NativeBuildOptions`, passed from `deploy.build.uuid`
- Replace two-step cache ref patching with single `appendCacheRefSegments(cacheRef, serviceName, buildUuid)`
- When `buildUuid` is undefined, falls back to service-name-only cache ref (backward compatible)

## Trade-offs

- First build per new environment will be a cold cache (no pre-existing cache to import)
- Subsequent builds in the same environment will hit their own isolated cache

## Test plan

- [x] Existing buildkit tests updated and passing (24/24)
- [x] New test for buildUuid:undefined fallback
- [x] Lint passes
- [x] No new TypeScript errors (all ts-check errors are pre-existing)
- [ ] Deploy to staging and verify builds create uuid-scoped cache refs in distribution registry
- [ ] Monitor for EOF errors over 48h to confirm reduction