### PR TITLE
fix: coerce env var values to strings for Kubernetes compatibility

### DIFF
--- a/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
+++ b/src/server/lib/nativeBuild/__tests__/buildkit.test.ts
@@ -247,6 +247,24 @@ describe('buildkitBuild', () => {
     expect(fullCommand).toContain('build-arg:NODE_ENV=production');
   });
 
+  it('coerces numeric env var values to strings for Kubernetes compatibility', async () => {
+    const optionsWithNumericEnv = {
+      ...mockOptions,
+      envVars: { APP_PORT: 3000, REPLICAS: 2, APP_NAME: 'my-app' } as any,
+    };
+
+    await buildkitBuild(mockDeploy, optionsWithNumericEnv);
+
+    const kubectlCalls = (shellPromise as jest.Mock).mock.calls;
+    const applyCall = kubectlCalls.find((call) => call[0].includes('kubectl apply'));
+    const fullCommand = applyCall[0];
+
+    expect(fullCommand).toContain('value: "3000"');
+    expect(fullCommand).toContain('value: "2"');
+    expect(fullCommand).toContain('value: "my-app"');
+    expect(fullCommand).not.toMatch(/value: [0-9]/);
+  });
+
   it('uses correct job naming pattern', async () => {
     const result = await buildkitBuild(mockDeploy, mockOptions);
 

--- a/src/server/lib/nativeBuild/__tests__/utils.test.ts
+++ b/src/server/lib/nativeBuild/__tests__/utils.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createGitCloneContainer, createBuildJobManifest } from '../utils';
+import { createGitCloneContainer, createBuildJobManifest, createJob } from '../utils';
 
 describe('nativeBuild/utils', () => {
   describe('createGitCloneContainer', () => {
@@ -112,6 +112,30 @@ describe('nativeBuild/utils', () => {
 
       const manifest = createBuildJobManifest(options);
       expect(manifest.spec.ttlSecondsAfterFinished).toBe(86400); // 24 hours for static builds
+    });
+  });
+
+  describe('createJob', () => {
+    it('coerces numeric env var values to strings', () => {
+      const job = createJob(
+        'test-job',
+        'test-ns',
+        'test-sa',
+        'alpine:latest',
+        ['sh', '-c'],
+        ['echo hello'],
+        { APP_NAME: 'my-app', APP_PORT: 8080, WORKERS: 4 } as any,
+        { app: 'test' },
+        { note: 'test' }
+      );
+
+      const envVars = job.spec!.template.spec!.containers![0].env!;
+      for (const envVar of envVars) {
+        expect(typeof envVar.value).toBe('string');
+      }
+      expect(envVars).toContainEqual({ name: 'APP_PORT', value: '8080' });
+      expect(envVars).toContainEqual({ name: 'WORKERS', value: '4' });
+      expect(envVars).toContainEqual({ name: 'APP_NAME', value: 'my-app' });
     });
   });
 });

--- a/src/server/lib/nativeBuild/engines.ts
+++ b/src/server/lib/nativeBuild/engines.ts
@@ -248,7 +248,7 @@ function createBuildContainer(
     image: engine.image,
     command: engine.command,
     args,
-    env: Object.entries(containerEnvVars).map(([envName, value]) => ({ name: envName, value })),
+    env: Object.entries(containerEnvVars).map(([envName, value]) => ({ name: envName, value: String(value) })),
     volumeMounts,
     resources,
   };

--- a/src/server/lib/nativeBuild/utils.ts
+++ b/src/server/lib/nativeBuild/utils.ts
@@ -93,7 +93,7 @@ export function createJob(
   },
   ttlSecondsAfterFinished?: number
 ): V1Job {
-  const env = Object.entries(envVars).map(([name, value]) => ({ name, value }));
+  const env = Object.entries(envVars).map(([name, value]) => ({ name, value: String(value) }));
 
   return {
     apiVersion: 'batch/v1',


### PR DESCRIPTION
## Summary

- Kubernetes requires all `env[].value` fields to be strings, but env vars sourced from JSONB storage can contain numeric values (e.g., port numbers stored as `5432` instead of `"5432"`)
- This causes `kubectl apply` to fail with: `cannot unmarshal number into Go struct field EnvVar.value of type string`
- Added `String()` coercion in both `engines.ts` (build container env) and `utils.ts` (deploy job env) where env var objects are constructed

## Test plan

- [x] Added test in `buildkit.test.ts` verifying numeric env values (e.g., `APP_PORT: 3000`) are coerced to strings in the generated job YAML
- [x] Added test in `utils.test.ts` verifying `createJob` coerces numeric env values to strings
- [x] All 29 nativeBuild tests pass
- [x] Lint passes