### PR TITLE
Revert "fix: escape inner double quotes in helm --set to preserve annotation key quoting"

### DIFF
--- a/src/server/lib/nativeHelm/__tests__/helm.test.ts
+++ b/src/server/lib/nativeHelm/__tests__/helm.test.ts
@@ -483,38 +483,6 @@ describe('Native Helm', () => {
       expect(result).not.toContain('--version');
     });
 
-    it('should preserve inner double quotes in --set keys for annotation paths', () => {
-      const result = constructHelmCommand(
-        'upgrade --install',
-        'my-chart',
-        'my-release',
-        'my-namespace',
-        ['ingress.extraAnnotations."app\\.kubernetes\\.io/name"=my-app'],
-        [],
-        ChartType.PUBLIC,
-        undefined,
-        'https://example.com/charts'
-      );
-
-      expect(result).toContain('--set "ingress.extraAnnotations.\\"app\\.kubernetes\\.io/name\\"=my-app"');
-    });
-
-    it('should escape inner double quotes in --set values', () => {
-      const result = constructHelmCommand(
-        'upgrade --install',
-        'my-chart',
-        'my-release',
-        'my-namespace',
-        ['deployment.env.MSG="hello world"'],
-        [],
-        ChartType.PUBLIC,
-        undefined,
-        'https://example.com/charts'
-      );
-
-      expect(result).toContain('--set "deployment.env.MSG=\\"hello world\\""');
-    });
-
     it('should not add chart version for PUBLIC charts when version is not specified', () => {
       const result = constructHelmCommand(
         'upgrade --install',

--- a/src/server/lib/nativeHelm/utils.ts
+++ b/src/server/lib/nativeHelm/utils.ts
@@ -93,12 +93,12 @@ export function constructHelmCommand(
   customValues.forEach((value) => {
     const equalIndex = value.indexOf('=');
     if (equalIndex > -1) {
-      const key = value.substring(0, equalIndex).replace(/"/g, '\\"');
+      const key = value.substring(0, equalIndex);
       const val = value.substring(equalIndex + 1);
-      const escapedVal = escapeHelmValue(val).replace(/"/g, '\\"');
+      const escapedVal = escapeHelmValue(val);
       command += ` --set "${key}=${escapedVal}"`;
     } else {
-      command += ` --set "${value.replace(/"/g, '\\"')}"`;
+      command += ` --set "${value}"`;
     }
   });
 


### PR DESCRIPTION
Reverts GoodRxOSS/lifecycle#151