### PR TITLE
pin axios to known-safe version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ FROM base AS packages
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 FROM packages
 

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -21,7 +21,7 @@ ENV PORT=$PORT
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 FROM packages
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@octokit/webhooks": "^12.0.1",
     "@types/react-syntax-highlighter": "^15.5.13",
     "aws-sdk": "^2.1004.0",
-    "axios": "^0.30.0",
+    "axios": "0.30.0",
     "bcryptjs": "^3.0.2",
     "bullmq": "5.56.8",
     "cockatiel": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         specifier: ^2.1004.0
         version: 2.1004.0
       axios:
-        specifier: ^0.30.0
+        specifier: 0.30.0
         version: 0.30.0
       bcryptjs:
         specifier: ^3.0.2


### PR DESCRIPTION
## What changed
- pin the direct `axios` dependency to `0.30.0` instead of allowing `^0.30.0`
- update the lockfile specifier to match the pinned dependency
- require `pnpm install --frozen-lockfile` in the Docker build paths that install app dependencies

## Why
Socket reported a supply-chain compromise affecting `axios@0.30.4` and `axios@1.14.1` on March 31, 2026:
https://socket.dev/blog/axios-npm-package-compromised

This repo's checked-in lockfile was already on `axios@0.30.0`, but the semver range still allowed a future re-resolve to the compromised `0.30.4` release. The Dockerfiles also allowed non-frozen installs, which could refresh the lock during image builds.

## Impact
- keeps the repo on the known-safe locked axios version
- prevents Docker builds from drifting away from the checked-in lockfile
- leaves unrelated local work untouched

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
