### PR TITLE
Generalize native Helm runner and post-renderer config

### DIFF
--- a/src/server/lib/config/ConfigBuilder.ts
+++ b/src/server/lib/config/ConfigBuilder.ts
@@ -16,19 +16,13 @@
 
 import { merge, cloneDeep } from 'lodash';
 import { mergeKeyValueArrays } from 'shared/utils';
+import {
+  NativeHelmConfig as GlobalNativeHelmConfig,
+  NativeHelmPostRendererConfig as GlobalNativeHelmPostRendererConfig,
+} from 'server/services/types/globalConfig';
 
-export interface HelmPostRendererConfig {
-  enabled?: boolean;
-  command?: string;
-  args?: string[];
-}
-
-export interface NativeHelmConfig {
-  enabled?: boolean;
-  defaultArgs?: string;
-  image?: string;
-  postRenderer?: HelmPostRendererConfig;
-}
+export type HelmPostRendererConfig = GlobalNativeHelmPostRendererConfig;
+export type NativeHelmConfig = Partial<GlobalNativeHelmConfig>;
 
 export interface HelmConfig {
   releaseName?: string;

--- a/src/server/lib/config/ConfigBuilder.ts
+++ b/src/server/lib/config/ConfigBuilder.ts
@@ -17,6 +17,19 @@
 import { merge, cloneDeep } from 'lodash';
 import { mergeKeyValueArrays } from 'shared/utils';
 
+export interface HelmPostRendererConfig {
+  enabled?: boolean;
+  command?: string;
+  args?: string[];
+}
+
+export interface NativeHelmConfig {
+  enabled?: boolean;
+  defaultArgs?: string;
+  image?: string;
+  postRenderer?: HelmPostRendererConfig;
+}
+
 export interface HelmConfig {
   releaseName?: string;
   chartPath?: string;
@@ -28,10 +41,7 @@ export interface HelmConfig {
   values?: Array<{ key: string; value: string }>;
   valueFiles?: string[];
   deploymentMethod?: 'native' | 'ci';
-  nativeHelm?: {
-    enabled?: boolean;
-    defaultArgs?: string;
-  };
+  nativeHelm?: NativeHelmConfig;
 }
 
 export interface BuildConfig {
@@ -54,9 +64,30 @@ export interface GlobalConfig {
     name?: string;
     role?: string;
   };
-  nativeHelm?: {
-    enabled?: boolean;
-    defaultArgs?: string;
+  nativeHelm?: NativeHelmConfig;
+}
+
+function mergePostRendererConfig(defaults?: HelmPostRendererConfig, current?: HelmPostRendererConfig) {
+  if (!defaults && !current) {
+    return undefined;
+  }
+
+  return {
+    ...defaults,
+    ...current,
+    args: current?.args !== undefined ? current.args : defaults?.args,
+  };
+}
+
+function mergeNativeHelmConfig(defaults?: NativeHelmConfig, current?: NativeHelmConfig) {
+  if (!defaults && !current) {
+    return undefined;
+  }
+
+  return {
+    ...defaults,
+    ...current,
+    postRenderer: mergePostRendererConfig(defaults?.postRenderer, current?.postRenderer),
   };
 }
 
@@ -139,7 +170,7 @@ export class HelmConfigBuilder extends ConfigBuilder<HelmConfig> {
       ...current,
       values: mergedValues,
       valueFiles: current.valueFiles?.length ? current.valueFiles : defaults.valueFiles || current.valueFiles || [],
-      nativeHelm: merge({}, defaults.nativeHelm, current.nativeHelm),
+      nativeHelm: mergeNativeHelmConfig(defaults.nativeHelm, current.nativeHelm),
     };
     return new HelmConfigBuilder(merged);
   }

--- a/src/server/lib/config/__tests__/ConfigBuilder.test.ts
+++ b/src/server/lib/config/__tests__/ConfigBuilder.test.ts
@@ -72,6 +72,41 @@ describe('ConfigBuilder', () => {
       expect(config.values).toContainEqual({ key: 'namespace', value: 'default' }); // Keep default
       expect(config.values).toContainEqual({ key: 'image.tag', value: 'v2.0.0' }); // Keep new value
     });
+
+    it('replaces post-renderer args while preserving inherited renderer config', () => {
+      const defaults = {
+        nativeHelm: {
+          enabled: true,
+          image: 'registry.example.com/helm-runner:1.0.0',
+          postRenderer: {
+            enabled: true,
+            command: '/opt/bin/post-renderer',
+            args: ['--global'],
+          },
+        },
+      };
+
+      const config = new HelmConfigBuilder()
+        .merge({
+          nativeHelm: {
+            postRenderer: {
+              args: ['--service'],
+            },
+          },
+        })
+        .mergeWithDefaults(defaults)
+        .build();
+
+      expect(config.nativeHelm).toEqual({
+        enabled: true,
+        image: 'registry.example.com/helm-runner:1.0.0',
+        postRenderer: {
+          enabled: true,
+          command: '/opt/bin/post-renderer',
+          args: ['--service'],
+        },
+      });
+    });
   });
 
   describe('BuildConfigBuilder', () => {

--- a/src/server/lib/nativeHelm/__tests__/helm.test.ts
+++ b/src/server/lib/nativeHelm/__tests__/helm.test.ts
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import { shouldUseNativeHelm, createHelmContainer, nativeHelmDeploy } from '../helm';
+import { shouldUseNativeHelm, createHelmContainer, nativeHelmDeploy, generateHelmManifest } from '../helm';
 import * as nativeHelmUtils from '../utils';
-import { determineChartType, constructHelmCommand, ChartType, constructHelmCustomValues } from '../utils';
+import {
+  determineChartType,
+  constructHelmCommand,
+  ChartType,
+  constructHelmCustomValues,
+  mergeHelmConfigWithGlobal,
+  validateHelmConfiguration,
+} from '../utils';
 import { RegistryAuthConfig } from '../registryAuth';
 import Deploy from 'server/models/Deploy';
 import GlobalConfigService from 'server/services/globalConfig';
@@ -24,6 +31,8 @@ import { buildDeployJobName } from 'server/lib/kubernetes/jobNames';
 import { waitForJobAndGetLogs } from 'server/lib/nativeBuild/utils';
 import { shellPromise } from 'server/lib/shell';
 import { getLogArchivalService } from 'server/services/logArchival';
+import { YamlConfigParser } from 'server/lib/yamlConfigParser';
+import * as YamlService from 'server/models/yaml';
 
 jest.mock('server/services/globalConfig');
 jest.mock('../utils', () => {
@@ -398,6 +407,32 @@ describe('Native Helm', () => {
       expect(result).not.toContain('--timeout 30m');
     });
 
+    it('should include a post-renderer command and args when configured', () => {
+      const result = constructHelmCommand(
+        'upgrade --install',
+        'my-chart',
+        'my-release',
+        'my-namespace',
+        ['key=value'],
+        ['values.yaml'],
+        ChartType.PUBLIC,
+        '--force --timeout 60m0s --wait',
+        undefined,
+        '--wait --timeout 30m',
+        '1.2.3',
+        {
+          enabled: true,
+          command: '/opt/bin/post-renderer',
+          args: ['--mode=prod', '--flag'],
+        }
+      );
+
+      expect(result).toContain("--post-renderer '/opt/bin/post-renderer'");
+      expect(result).toContain("--post-renderer-args '--mode=prod'");
+      expect(result).toContain("--post-renderer-args '--flag'");
+      expect(result).toContain('--version 1.2.3');
+    });
+
     it('should handle OCI chart URLs correctly', () => {
       const result = constructHelmCommand(
         'upgrade --install',
@@ -573,6 +608,170 @@ describe('Native Helm', () => {
       expect(result.args).toHaveLength(1);
       expect(result.args[0]).toContain('helm upgrade --install');
       expect(result.args[0]).toContain('--force --timeout 60m0s --wait');
+    });
+
+    it('should use a configured custom helm image and post-renderer config', async () => {
+      const result = await createHelmContainer(
+        'org/repo',
+        'my-chart',
+        'my-release',
+        'my-namespace',
+        '3.12.0',
+        ['key=value'],
+        ['values.yaml'],
+        ChartType.PUBLIC,
+        'my-service',
+        'my-job-name',
+        '--force --timeout 60m0s --wait',
+        'https://charts.example.com',
+        '--wait --timeout 30m',
+        '1.2.3',
+        undefined,
+        'registry.example.com/custom-helm-runner:1.2.3',
+        {
+          enabled: true,
+          command: '/opt/bin/post-renderer',
+          args: ['--mode=prod'],
+        }
+      );
+
+      expect(result.image).toBe('registry.example.com/custom-helm-runner:1.2.3');
+      expect(result.args[0]).toContain("--post-renderer '/opt/bin/post-renderer'");
+      expect(result.args[0]).toContain("--post-renderer-args '--mode=prod'");
+    });
+  });
+
+  describe('mergeHelmConfigWithGlobal', () => {
+    it('applies helmDefaults nativeHelm config when no service override is provided', async () => {
+      mockGetAllConfigs.mockResolvedValue({
+        helmDefaults: {
+          nativeHelm: {
+            enabled: true,
+            image: 'registry.example.com/default-helm-runner:1.0.0',
+            postRenderer: {
+              enabled: true,
+              command: '/opt/bin/post-renderer',
+              args: ['--global'],
+            },
+          },
+        },
+        redis: {
+          chart: {
+            name: 'redis',
+            repoUrl: 'https://charts.bitnami.com/bitnami',
+          },
+        },
+      });
+
+      const deploy = {
+        deployable: {
+          helm: {
+            chart: { name: 'redis' },
+          },
+        },
+      } as any;
+
+      const result = await mergeHelmConfigWithGlobal(deploy);
+
+      expect(result.nativeHelm).toEqual({
+        enabled: true,
+        image: 'registry.example.com/default-helm-runner:1.0.0',
+        postRenderer: {
+          enabled: true,
+          command: '/opt/bin/post-renderer',
+          args: ['--global'],
+        },
+      });
+    });
+
+    it('allows service config to override global image and renderer args', async () => {
+      mockGetAllConfigs.mockResolvedValue({
+        helmDefaults: {
+          nativeHelm: {
+            enabled: true,
+            image: 'registry.example.com/default-helm-runner:1.0.0',
+            postRenderer: {
+              enabled: true,
+              command: '/opt/bin/post-renderer',
+              args: ['--global'],
+            },
+          },
+        },
+        redis: {
+          nativeHelm: {
+            postRenderer: {
+              args: ['--chart'],
+            },
+          },
+          chart: {
+            name: 'redis',
+          },
+        },
+      });
+
+      const deploy = {
+        deployable: {
+          helm: {
+            chart: { name: 'redis' },
+            nativeHelm: {
+              image: 'registry.example.com/service-helm-runner:2.0.0',
+              postRenderer: {
+                args: ['--service'],
+              },
+            },
+          },
+        },
+      } as any;
+
+      const result = await mergeHelmConfigWithGlobal(deploy);
+
+      expect(result.nativeHelm).toEqual({
+        enabled: true,
+        image: 'registry.example.com/service-helm-runner:2.0.0',
+        postRenderer: {
+          enabled: true,
+          command: '/opt/bin/post-renderer',
+          args: ['--service'],
+        },
+      });
+    });
+
+    it('allows service config to disable an inherited global renderer', async () => {
+      mockGetAllConfigs.mockResolvedValue({
+        helmDefaults: {
+          nativeHelm: {
+            enabled: true,
+            image: 'registry.example.com/default-helm-runner:1.0.0',
+            postRenderer: {
+              enabled: true,
+              command: '/opt/bin/post-renderer',
+              args: ['--global'],
+            },
+          },
+        },
+        redis: {
+          chart: {
+            name: 'redis',
+          },
+        },
+      });
+
+      const deploy = {
+        deployable: {
+          helm: {
+            chart: { name: 'redis' },
+            nativeHelm: {
+              postRenderer: {
+                enabled: false,
+              },
+            },
+          },
+        },
+      } as any;
+
+      const result = await mergeHelmConfigWithGlobal(deploy);
+
+      expect(result.nativeHelm?.postRenderer?.enabled).toBe(false);
     });
   });
 
@@ -1062,6 +1261,67 @@ describe('Native Helm', () => {
     });
   });
 
+  describe('validateHelmConfiguration', () => {
+    it('accepts a globally configured custom image without a service-level helm version', async () => {
+      mockGetAllConfigs.mockResolvedValue({
+        helmDefaults: {
+          nativeHelm: {
+            enabled: true,
+            image: 'registry.example.com/default-helm-runner:1.0.0',
+          },
+        },
+        redis: {
+          chart: {
+            name: 'redis',
+          },
+        },
+      });
+
+      const deploy = {
+        deployable: {
+          helm: {
+            chart: { name: 'redis' },
+          },
+        },
+      } as any;
+
+      const errors = await validateHelmConfiguration(deploy);
+
+      expect(errors).toEqual([]);
+    });
+
+    it('requires a post-renderer command when renderer is enabled', async () => {
+      mockGetAllConfigs.mockResolvedValue({
+        helmDefaults: {
+          nativeHelm: {
+            enabled: true,
+            image: 'registry.example.com/default-helm-runner:1.0.0',
+            postRenderer: {
+              enabled: true,
+            },
+          },
+        },
+        redis: {
+          chart: {
+            name: 'redis',
+          },
+        },
+      });
+
+      const deploy = {
+        deployable: {
+          helm: {
+            chart: { name: 'redis' },
+          },
+        },
+      } as any;
+
+      const errors = await validateHelmConfiguration(deploy);
+
+      expect(errors).toContain('Native Helm post-renderer command is required when post-renderer is enabled');
+    });
+  });
+
   describe('nativeHelmDeploy', () => {
     it('uses the canonical deploy job name for monitoring and archival', async () => {
       const deploy = {
@@ -1142,6 +1402,230 @@ describe('Native Helm', () => {
       });
 
       setTimeoutSpy.mockRestore();
+    });
+  });
+
+  describe('generateHelmManifest', () => {
+    it('builds the expected manifest for plain native Helm without a renderer', async () => {
+      mockGetAllConfigs.mockResolvedValue({
+        publicChart: { block: false },
+        helmDefaults: {
+          nativeHelm: {
+            enabled: true,
+            defaultArgs: '--wait --timeout 30m',
+            defaultHelmVersion: '3.12.0',
+          },
+        },
+        'sample-chart': {
+          chart: {
+            name: 'sample-chart',
+            repoUrl: 'https://charts.example.com',
+            version: '2.5.1',
+          },
+        },
+      });
+
+      const parser = new YamlConfigParser();
+      const lifecycleYaml = `---
+version: '1.0.0'
+services:
+  - name: sample-service
+    helm:
+      deploymentMethod: native
+      chart:
+        name: sample-chart
+`;
+
+      const config = parser.parseYamlConfigFromString(lifecycleYaml);
+      const service = YamlService.getDeployingServicesByName(config, 'sample-service');
+      const helmConfig = await YamlService.getHelmConfigFromYaml(service);
+
+      (nativeHelmUtils.getHelmConfiguration as jest.Mock).mockResolvedValue({
+        chartType: ChartType.PUBLIC,
+        customValues: [],
+        valuesFiles: [],
+        chartPath: helmConfig.chart?.name || 'sample-chart',
+        releaseName: 'sample-release',
+        helmVersion: '3.12.0',
+      });
+      (nativeHelmUtils.determineChartType as jest.Mock).mockResolvedValue(ChartType.PUBLIC);
+      (nativeHelmUtils.mergeHelmConfigWithGlobal as jest.Mock).mockImplementation(
+        jest.requireActual('../utils').mergeHelmConfigWithGlobal
+      );
+
+      const deploy = {
+        uuid: 'sample-release',
+        sha: 'abcdef1234567890',
+        branchName: 'main',
+        id: 42,
+        deployableId: 99,
+        deployable: {
+          name: 'sample-service',
+          helm: helmConfig,
+        },
+        build: {
+          uuid: 'build-123',
+          namespace: 'testns',
+          isStatic: false,
+        },
+        $fetchGraph: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const manifest = await generateHelmManifest(deploy, 'test-job', { namespace: 'testns' });
+
+      expect(manifest).toContain('image: alpine/helm:3.12.0');
+      expect(manifest).not.toContain('--post-renderer');
+      expect(manifest).not.toContain('--post-renderer-args');
+      expect(manifest).toContain('--wait --timeout 30m');
+    });
+
+    it('uses merged global nativeHelm image and post-renderer config', async () => {
+      mockGetAllConfigs.mockResolvedValue({
+        helmDefaults: {
+          nativeHelm: {
+            enabled: true,
+            image: 'registry.example.com/custom-helm-runner:1.2.3',
+            postRenderer: {
+              enabled: true,
+              command: '/opt/bin/post-renderer',
+              args: ['--mode=prod'],
+            },
+          },
+        },
+        redis: {
+          chart: {
+            name: 'redis',
+            repoUrl: 'https://charts.bitnami.com/bitnami',
+          },
+        },
+      });
+
+      (nativeHelmUtils.getHelmConfiguration as jest.Mock).mockResolvedValue({
+        chartType: ChartType.PUBLIC,
+        customValues: [],
+        valuesFiles: [],
+        chartPath: 'redis',
+        releaseName: 'test-release',
+        helmVersion: '3.12.0',
+      });
+      (nativeHelmUtils.determineChartType as jest.Mock).mockResolvedValue(ChartType.PUBLIC);
+      (nativeHelmUtils.mergeHelmConfigWithGlobal as jest.Mock).mockImplementation(
+        jest.requireActual('../utils').mergeHelmConfigWithGlobal
+      );
+
+      const deploy = {
+        uuid: 'test-release',
+        sha: 'abcdef1234567890',
+        branchName: 'main',
+        id: 42,
+        deployableId: 99,
+        deployable: {
+          name: 'redis',
+          helm: {
+            chart: { name: 'redis' },
+          },
+        },
+        build: {
+          uuid: 'build-123',
+          namespace: 'testns',
+          isStatic: false,
+        },
+        $fetchGraph: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const manifest = await generateHelmManifest(deploy, 'test-job', { namespace: 'testns' });
+
+      expect(manifest).toContain('image: registry.example.com/custom-helm-runner:1.2.3');
+      expect(manifest).toContain("--post-renderer '/opt/bin/post-renderer'");
+      expect(manifest).toContain("--post-renderer-args '--mode=prod'");
+    });
+
+    it('builds the expected manifest from global config plus lifecycle yaml', async () => {
+      mockGetAllConfigs.mockResolvedValue({
+        publicChart: { block: false },
+        helmDefaults: {
+          nativeHelm: {
+            enabled: true,
+            image: 'registry.example.com/default-helm-runner:1.0.0',
+            postRenderer: {
+              enabled: true,
+              command: '/opt/bin/post-renderer',
+              args: ['--global'],
+            },
+          },
+        },
+        'sample-chart': {
+          chart: {
+            name: 'sample-chart',
+            repoUrl: 'https://charts.example.com',
+            version: '2.5.1',
+            valueFiles: ['global-values.yaml'],
+          },
+        },
+      });
+
+      const parser = new YamlConfigParser();
+      const lifecycleYaml = `---
+version: '1.0.0'
+services:
+  - name: sample-service
+    helm:
+      deploymentMethod: native
+      chart:
+        name: sample-chart
+        valueFiles:
+          - service-values.yaml
+      nativeHelm:
+        image: registry.example.com/service-helm-runner:2.0.0
+        postRenderer:
+          enabled: true
+          args:
+            - --service-override
+`;
+
+      const config = parser.parseYamlConfigFromString(lifecycleYaml);
+      const service = YamlService.getDeployingServicesByName(config, 'sample-service');
+      const helmConfig = await YamlService.getHelmConfigFromYaml(service);
+
+      (nativeHelmUtils.getHelmConfiguration as jest.Mock).mockResolvedValue({
+        chartType: ChartType.PUBLIC,
+        customValues: [],
+        valuesFiles: helmConfig.chart?.valueFiles || [],
+        chartPath: helmConfig.chart?.name || 'sample-chart',
+        releaseName: 'sample-release',
+        helmVersion: '3.12.0',
+      });
+      (nativeHelmUtils.determineChartType as jest.Mock).mockResolvedValue(ChartType.PUBLIC);
+      (nativeHelmUtils.mergeHelmConfigWithGlobal as jest.Mock).mockImplementation(
+        jest.requireActual('../utils').mergeHelmConfigWithGlobal
+      );
+
+      const deploy = {
+        uuid: 'sample-release',
+        sha: 'abcdef1234567890',
+        branchName: 'main',
+        id: 42,
+        deployableId: 99,
+        deployable: {
+          name: 'sample-service',
+          helm: helmConfig,
+        },
+        build: {
+          uuid: 'build-123',
+          namespace: 'testns',
+          isStatic: false,
+        },
+        $fetchGraph: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const manifest = await generateHelmManifest(deploy, 'test-job', { namespace: 'testns' });
+
+      expect(manifest).toContain('image: registry.example.com/service-helm-runner:2.0.0');
+      expect(manifest).toContain("--post-renderer '/opt/bin/post-renderer'");
+      expect(manifest).toContain("--post-renderer-args '--service-override'");
+      expect(manifest).not.toContain("--post-renderer-args '--global'");
+      expect(manifest).toContain('-f service-values.yaml');
+      expect(manifest).not.toContain('-f global-values.yaml');
     });
   });
 });

--- a/src/server/lib/nativeHelm/helm.ts
+++ b/src/server/lib/nativeHelm/helm.ts
@@ -36,6 +36,7 @@ import { fetchUntilSuccess } from 'server/lib/helm/helm';
 import {
   HelmDeployOptions,
   ChartType,
+  HelmPostRendererConfig,
   determineChartType,
   getHelmConfiguration,
   generateHelmInstallScript,
@@ -76,7 +77,9 @@ export async function createHelmContainer(
   chartRepoUrl?: string,
   defaultArgs?: string,
   chartVersion?: string,
-  registryAuth?: RegistryAuthConfig
+  registryAuth?: RegistryAuthConfig,
+  helmImage?: string,
+  postRenderer?: HelmPostRendererConfig
 ): Promise<any> {
   const script = generateHelmInstallScript(
     repoName,
@@ -90,12 +93,13 @@ export async function createHelmContainer(
     chartRepoUrl,
     defaultArgs,
     chartVersion,
-    registryAuth
+    registryAuth,
+    postRenderer
   );
 
   return {
     name: 'helm-deploy',
-    image: `${HELM_IMAGE_PREFIX}:${helmVersion}`,
+    image: helmImage || `${HELM_IMAGE_PREFIX}:${helmVersion}`,
     env: [
       { name: 'HELM_CACHE_HOME', value: '/workspace/.helm/cache' },
       { name: 'HELM_CONFIG_HOME', value: '/workspace/.helm/config' },
@@ -145,6 +149,8 @@ export async function generateHelmManifest(
   const helmArgs = mergedHelmConfig.args;
   const defaultArgs = mergedHelmConfig.nativeHelm?.defaultArgs;
   const registryAuth = detectRegistryAuth(chartRepoUrl);
+  const helmImage = mergedHelmConfig.nativeHelm?.image;
+  const postRenderer = mergedHelmConfig.nativeHelm?.postRenderer;
 
   const helmContainer = await createHelmContainer(
     repository?.fullName || 'no-repo',
@@ -161,7 +167,9 @@ export async function generateHelmManifest(
     chartRepoUrl,
     defaultArgs,
     chartVersion,
-    registryAuth
+    registryAuth,
+    helmImage,
+    postRenderer
   );
 
   const volumeConfig = {

--- a/src/server/lib/nativeHelm/utils.ts
+++ b/src/server/lib/nativeHelm/utils.ts
@@ -28,6 +28,10 @@ import {
 } from 'server/lib/kubernetes/rbac';
 import { getLogger } from 'server/lib/logger';
 import { normalizeKubernetesLabelValue } from 'server/lib/kubernetes/utils';
+import {
+  NativeHelmConfig as GlobalNativeHelmConfig,
+  NativeHelmPostRendererConfig,
+} from 'server/services/types/globalConfig';
 
 export interface HelmDeployOptions {
   namespace: string;
@@ -43,17 +47,11 @@ export interface HelmConfiguration {
   helmVersion: string;
 }
 
-export interface HelmPostRendererConfig {
-  enabled?: boolean;
-  command?: string;
-  args?: string[];
-}
-
 function shellEscape(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function buildPostRendererFlags(postRenderer?: HelmPostRendererConfig): string {
+function buildPostRendererFlags(postRenderer?: NativeHelmPostRendererConfig): string {
   if (!postRenderer?.command || postRenderer.enabled === false) {
     return '';
   }
@@ -68,10 +66,10 @@ function buildPostRendererFlags(postRenderer?: HelmPostRendererConfig): string {
 }
 
 function mergePostRendererConfig(
-  defaults?: HelmPostRendererConfig,
-  chartConfig?: HelmPostRendererConfig,
-  current?: HelmPostRendererConfig
-): HelmPostRendererConfig | undefined {
+  defaults?: NativeHelmPostRendererConfig,
+  chartConfig?: NativeHelmPostRendererConfig,
+  current?: NativeHelmPostRendererConfig
+): NativeHelmPostRendererConfig | undefined {
   if (!defaults && !chartConfig && !current) {
     return undefined;
   }
@@ -85,20 +83,10 @@ function mergePostRendererConfig(
   };
 }
 
-interface NativeHelmOverrideConfig {
-  enabled?: boolean;
-  defaultHelmVersion?: string;
-  jobTimeout?: number;
-  serviceAccount?: string;
-  defaultArgs?: string;
-  image?: string;
-  postRenderer?: HelmPostRendererConfig;
-}
-
 function mergeNativeHelmConfig(
-  defaults?: NativeHelmOverrideConfig,
-  chartConfig?: NativeHelmOverrideConfig,
-  current?: NativeHelmOverrideConfig
+  defaults?: Partial<GlobalNativeHelmConfig>,
+  chartConfig?: Partial<GlobalNativeHelmConfig>,
+  current?: Partial<GlobalNativeHelmConfig>
 ) {
   if (!defaults && !chartConfig && !current) {
     return undefined;
@@ -124,7 +112,7 @@ export function constructHelmCommand(
   chartRepoUrl?: string,
   defaultArgs?: string,
   chartVersion?: string,
-  postRenderer?: HelmPostRendererConfig
+  postRenderer?: NativeHelmPostRendererConfig
 ): string {
   let command = `helm ${action} ${releaseName}`;
 
@@ -202,7 +190,7 @@ export function generateHelmInstallScript(
   defaultArgs?: string,
   chartVersion?: string,
   registryAuth?: RegistryAuthConfig,
-  postRenderer?: HelmPostRendererConfig
+  postRenderer?: NativeHelmPostRendererConfig
 ): string {
   const helmCommand = constructHelmCommand(
     'upgrade --install',

--- a/src/server/lib/nativeHelm/utils.ts
+++ b/src/server/lib/nativeHelm/utils.ts
@@ -26,7 +26,6 @@ import {
   createServiceAccountUsingExistingFunction,
   setupDeployServiceAccountInNamespace,
 } from 'server/lib/kubernetes/rbac';
-import { HelmConfigBuilder } from 'server/lib/config/ConfigBuilder';
 import { getLogger } from 'server/lib/logger';
 import { normalizeKubernetesLabelValue } from 'server/lib/kubernetes/utils';
 
@@ -44,6 +43,75 @@ export interface HelmConfiguration {
   helmVersion: string;
 }
 
+export interface HelmPostRendererConfig {
+  enabled?: boolean;
+  command?: string;
+  args?: string[];
+}
+
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function buildPostRendererFlags(postRenderer?: HelmPostRendererConfig): string {
+  if (!postRenderer?.command || postRenderer.enabled === false) {
+    return '';
+  }
+
+  let flags = ` --post-renderer ${shellEscape(postRenderer.command)}`;
+
+  (postRenderer.args || []).forEach((arg) => {
+    flags += ` --post-renderer-args ${shellEscape(arg)}`;
+  });
+
+  return flags;
+}
+
+function mergePostRendererConfig(
+  defaults?: HelmPostRendererConfig,
+  chartConfig?: HelmPostRendererConfig,
+  current?: HelmPostRendererConfig
+): HelmPostRendererConfig | undefined {
+  if (!defaults && !chartConfig && !current) {
+    return undefined;
+  }
+
+  return {
+    ...defaults,
+    ...chartConfig,
+    ...current,
+    args:
+      current?.args !== undefined ? current.args : chartConfig?.args !== undefined ? chartConfig.args : defaults?.args,
+  };
+}
+
+interface NativeHelmOverrideConfig {
+  enabled?: boolean;
+  defaultHelmVersion?: string;
+  jobTimeout?: number;
+  serviceAccount?: string;
+  defaultArgs?: string;
+  image?: string;
+  postRenderer?: HelmPostRendererConfig;
+}
+
+function mergeNativeHelmConfig(
+  defaults?: NativeHelmOverrideConfig,
+  chartConfig?: NativeHelmOverrideConfig,
+  current?: NativeHelmOverrideConfig
+) {
+  if (!defaults && !chartConfig && !current) {
+    return undefined;
+  }
+
+  return {
+    ...defaults,
+    ...chartConfig,
+    ...current,
+    postRenderer: mergePostRendererConfig(defaults?.postRenderer, chartConfig?.postRenderer, current?.postRenderer),
+  };
+}
+
 export function constructHelmCommand(
   action: string,
   chartPath: string,
@@ -55,7 +123,8 @@ export function constructHelmCommand(
   args?: string,
   chartRepoUrl?: string,
   defaultArgs?: string,
-  chartVersion?: string
+  chartVersion?: string,
+  postRenderer?: HelmPostRendererConfig
 ): string {
   let command = `helm ${action} ${releaseName}`;
 
@@ -89,6 +158,8 @@ export function constructHelmCommand(
   if (chartVersion && (chartType === ChartType.PUBLIC || chartType === ChartType.ORG_CHART)) {
     command += ` --version ${chartVersion}`;
   }
+
+  command += buildPostRendererFlags(postRenderer);
 
   customValues.forEach((value) => {
     const equalIndex = value.indexOf('=');
@@ -130,7 +201,8 @@ export function generateHelmInstallScript(
   chartRepoUrl?: string,
   defaultArgs?: string,
   chartVersion?: string,
-  registryAuth?: RegistryAuthConfig
+  registryAuth?: RegistryAuthConfig,
+  postRenderer?: HelmPostRendererConfig
 ): string {
   const helmCommand = constructHelmCommand(
     'upgrade --install',
@@ -143,7 +215,8 @@ export function generateHelmInstallScript(
     args,
     chartRepoUrl,
     defaultArgs,
-    chartVersion
+    chartVersion,
+    postRenderer
   );
 
   let script = [
@@ -269,61 +342,48 @@ export async function mergeHelmConfigWithGlobal(deploy: Deploy): Promise<any> {
   const helm: any = deployable.helm || {};
   const configs = await GlobalConfigService.getInstance().getAllConfigs();
   const chartName = helm?.chart?.name;
+  const helmDefaults = configs.helmDefaults || {};
+  const chartConfig = chartName ? configs[chartName] || {} : {};
 
-  const globalConfig = configs[chartName];
-  if (!globalConfig) {
+  if (!chartName && !helmDefaults.nativeHelm) {
     return helm;
   }
 
-  // Use builder pattern for cleaner configuration merging
-  const builder = new HelmConfigBuilder(helm);
-
-  // Apply global config with proper precedence
-  if (globalConfig.version && !helm.version) {
-    builder.set('helmVersion', globalConfig.version);
-  }
-  if (globalConfig.args && !helm.args) {
-    builder.set('args', globalConfig.args);
-  }
-
-  // Build merged config with original structure
   const mergedConfig = {
+    ...helmDefaults,
+    ...chartConfig,
     ...helm,
 
-    ...(globalConfig.version && { version: globalConfig.version }),
-    ...(globalConfig.args && { args: globalConfig.args }),
-    ...(globalConfig.action && { action: globalConfig.action }),
-
-    label: globalConfig.label,
-    tolerations: globalConfig.tolerations,
-    affinity: globalConfig.affinity,
-    nodeSelector: globalConfig.nodeSelector,
+    label: helm.label ?? chartConfig.label ?? helmDefaults.label,
+    tolerations: helm.tolerations ?? chartConfig.tolerations ?? helmDefaults.tolerations,
+    affinity: helm.affinity ?? chartConfig.affinity ?? helmDefaults.affinity,
+    nodeSelector: helm.nodeSelector ?? chartConfig.nodeSelector ?? helmDefaults.nodeSelector,
 
     grpc: helm.grpc,
     disableIngressHost: helm.disableIngressHost,
     deploymentMethod: helm.deploymentMethod,
-    nativeHelm: helm.nativeHelm,
     type: helm.type,
     docker: helm.docker,
     envMapping: helm.envMapping,
-
-    ...(helm.version && { version: helm.version }),
-    ...(helm.args && { args: helm.args }),
-    ...(helm.action && { action: helm.action }),
+    nativeHelm: mergeNativeHelmConfig(helmDefaults.nativeHelm, chartConfig.nativeHelm, helm.nativeHelm),
   };
 
-  if (globalConfig.chart || helm.chart) {
-    mergedConfig.chart = mergeChartConfig(helm.chart, globalConfig.chart);
+  if (helmDefaults.chart || chartConfig.chart || helm.chart) {
+    mergedConfig.chart = mergeChartConfig(helmDefaults.chart, chartConfig.chart, helm.chart);
   }
 
   return mergedConfig;
 }
 
-function mergeChartConfig(helmChart: any, globalChart: any): any {
-  return {
-    ...(helmChart || {}),
+function mergeChartConfig(defaultChart: any, chartConfig: any, helmChart: any): any {
+  const mergedGlobalValues = chartConfig?.values?.length
+    ? mergeKeyValueArrays(defaultChart?.values || [], chartConfig.values, '=')
+    : defaultChart?.values || chartConfig?.values || [];
 
-    ...(globalChart || {}),
+  return {
+    ...(defaultChart || {}),
+    ...(chartConfig || {}),
+    ...(helmChart || {}),
 
     ...(helmChart?.name && { name: helmChart.name }),
     ...(helmChart?.repoUrl && { repoUrl: helmChart.repoUrl }),
@@ -331,13 +391,15 @@ function mergeChartConfig(helmChart: any, globalChart: any): any {
 
     values:
       helmChart?.values && helmChart.values.length > 0
-        ? mergeKeyValueArrays(globalChart?.values || [], helmChart.values, '=')
-        : globalChart?.values || helmChart?.values || [],
+        ? mergeKeyValueArrays(mergedGlobalValues, helmChart.values, '=')
+        : mergedGlobalValues,
 
     valueFiles:
       helmChart?.valueFiles && helmChart.valueFiles.length > 0
         ? helmChart.valueFiles
-        : globalChart?.valueFiles || helmChart?.valueFiles || [],
+        : chartConfig?.valueFiles?.length
+        ? chartConfig.valueFiles
+        : defaultChart?.valueFiles || helmChart?.valueFiles || [],
   };
 }
 
@@ -849,8 +911,7 @@ export function escapeHelmValue(value: string): string {
 
 export async function validateHelmConfiguration(deploy: Deploy): Promise<string[]> {
   const errors: string[] = [];
-  const { deployable } = deploy;
-  const helm = deployable.helm;
+  const helm = await mergeHelmConfigWithGlobal(deploy);
 
   if (!helm) {
     errors.push('Helm configuration is missing');
@@ -863,8 +924,16 @@ export async function validateHelmConfiguration(deploy: Deploy): Promise<string[
 
   // Check for helm version in multiple locations
   const helmVersion = helm.version || helm.nativeHelm?.defaultHelmVersion;
-  if (!helmVersion) {
+  if (!helmVersion && !helm.nativeHelm?.image) {
     errors.push('Helm version is required');
+  }
+
+  if (
+    helm.nativeHelm?.postRenderer?.enabled !== false &&
+    helm.nativeHelm?.postRenderer &&
+    !helm.nativeHelm.postRenderer.command
+  ) {
+    errors.push('Native Helm post-renderer command is required when post-renderer is enabled');
   }
 
   const chartType = await determineChartType(deploy);

--- a/src/server/services/types/globalConfig.ts
+++ b/src/server/services/types/globalConfig.ts
@@ -116,12 +116,20 @@ export type HelmDefaults = {
   nativeHelm?: NativeHelmConfig;
 };
 
+export type NativeHelmPostRendererConfig = {
+  enabled?: boolean;
+  command?: string;
+  args?: string[];
+};
+
 export type NativeHelmConfig = {
   enabled: boolean;
   defaultHelmVersion?: string;
   jobTimeout?: number;
   serviceAccount?: string;
   defaultArgs?: string;
+  image?: string;
+  postRenderer?: NativeHelmPostRendererConfig;
 };
 
 export type BuildDefaults = {


### PR DESCRIPTION
## What changed
- add native Helm support for a configurable runner image
- add generic post-renderer config with `enabled`, `command`, and `args`
- merge native Helm config from global defaults, chart config, and service config with service overrides winning
- validate merged native Helm config rather than only raw service config
- add tests for default behavior, global config, overrides, disable semantics, and manifest generation from lifecycle YAML

## Why
This lets native Helm deployments support custom runner images and Helm post-renderers without relying on CI-specific deploy steps.

## Validation
- `pnpm exec jest src/server/lib/config/__tests__/ConfigBuilder.test.ts --runInBand`
- `pnpm exec jest src/server/lib/nativeHelm/__tests__/helm.test.ts --runInBand`
- `pnpm test`
