### PR TITLE
feat: update YAML schema for native Helm config attributes

### DIFF
--- a/docs/schema/yaml/1.0.0.yaml
+++ b/docs/schema/yaml/1.0.0.yaml
@@ -219,6 +219,32 @@ services:
           # @param services.helm.docker.init.env
           env:
 
+      # @param services.helm.deploymentMethod
+      deploymentMethod: ''
+      # @param services.helm.nativeHelm
+      nativeHelm:
+        # @param services.helm.nativeHelm.enabled
+        enabled: false
+        # @param services.helm.nativeHelm.defaultHelmVersion
+        defaultHelmVersion: ''
+        # @param services.helm.nativeHelm.jobTimeout
+        jobTimeout: 0
+        # @param services.helm.nativeHelm.serviceAccount
+        serviceAccount: ''
+        # @param services.helm.nativeHelm.defaultArgs
+        defaultArgs: ''
+        # @param services.helm.nativeHelm.image
+        image: ''
+        # @param services.helm.nativeHelm.postRenderer
+        postRenderer:
+          # @param services.helm.nativeHelm.postRenderer.enabled
+          enabled: false
+          # @param services.helm.nativeHelm.postRenderer.command
+          command: ''
+          # @param services.helm.nativeHelm.postRenderer.args
+          args:
+            # @param services.helm.nativeHelm.postRenderer.args[]
+            - ''
     # @param services.codefresh
     codefresh:
       # @param services.codefresh.repository (required)

--- a/src/server/lib/jsonschema/schemas/1.0.0.json
+++ b/src/server/lib/jsonschema/schemas/1.0.0.json
@@ -429,6 +429,55 @@
                   "defaultTag",
                   "app"
                 ]
+              },
+              "deploymentMethod": {
+                "type": "string",
+                "enum": [
+                  "native",
+                  "ci"
+                ]
+              },
+              "nativeHelm": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "defaultHelmVersion": {
+                    "type": "string"
+                  },
+                  "jobTimeout": {
+                    "type": "number"
+                  },
+                  "serviceAccount": {
+                    "type": "string"
+                  },
+                  "defaultArgs": {
+                    "type": "string"
+                  },
+                  "image": {
+                    "type": "string"
+                  },
+                  "postRenderer": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "command": {
+                        "type": "string"
+                      },
+                      "args": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           },

--- a/src/server/lib/yamlSchemas/schema_1_0_0/schema_1_0_0.ts
+++ b/src/server/lib/yamlSchemas/schema_1_0_0/schema_1_0_0.ts
@@ -107,6 +107,7 @@ const schema_1_0_0 = {
               action: { type: 'string' },
               repository: { type: 'string' },
               branchName: { type: 'string' },
+              deploymentMethod: { type: 'string', enum: ['native', 'ci'] },
               chart: {
                 type: 'object',
                 additionalProperties: false,
@@ -118,6 +119,27 @@ const schema_1_0_0 = {
                   valueFiles: { type: 'array', items: { type: 'string' } },
                 },
                 required: ['name'],
+              },
+              nativeHelm: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  enabled: { type: 'boolean' },
+                  defaultHelmVersion: { type: 'string' },
+                  jobTimeout: { type: 'number' },
+                  serviceAccount: { type: 'string' },
+                  defaultArgs: { type: 'string' },
+                  image: { type: 'string' },
+                  postRenderer: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                      enabled: { type: 'boolean' },
+                      command: { type: 'string' },
+                      args: { type: 'array', items: { type: 'string' } },
+                    },
+                  },
+                },
               },
               envLens: { type: 'boolean' },
               grpc: { type: 'boolean' },


### PR DESCRIPTION
## Summary
- add `helm.deploymentMethod` to the 1.0.0 lifecycle YAML schema
- add `helm.nativeHelm` and `helm.nativeHelm.postRenderer` to the schema
- regenerate the published JSON schema and YAML schema docs

## Notes
- no runtime behavior changes
- `helm.additionalProperties` remains unchanged in this follow-up