### PR TITLE
fix: clarify PR env override examples

### DIFF
--- a/src/server/lib/__tests__/comment.test.ts
+++ b/src/server/lib/__tests__/comment.test.ts
@@ -29,8 +29,8 @@ describe('CommentHelper.parseEnvironmentOverrides', () => {
       'Status comment',
       CommentParser.HEADER,
       '// **Override Environment Variables (add one override per line below)**',
-      '// Example ENV:FEATURE_ENABLED:true',
-      '// Example ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api',
+      '// ENV:FEATURE_ENABLED:true',
+      '// ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api',
       'ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api/v1',
       'ENV:FEATURE_FLAGS.checkout:true',
       CommentParser.FOOTER,
@@ -54,6 +54,23 @@ describe('CommentHelper.parseEnvironmentOverrides', () => {
 
     expect(CommentHelper.parseEnvironmentOverrides(comment)).toEqual({
       BANNER_TEXT: 'sample lifecycle banner',
+    });
+  });
+
+  test('trims separator-adjacent whitespace from keys and values', () => {
+    const comment = [
+      'Status comment',
+      CommentParser.HEADER,
+      'ENV: FEATURE_ENABLED:true',
+      'ENV:BANNER_TEXT: sample lifecycle banner',
+      'ENV: LIFECYCLE_API_URL : https://app.lifecycle.com/api/v1 ',
+      CommentParser.FOOTER,
+    ].join('\n');
+
+    expect(CommentHelper.parseEnvironmentOverrides(comment)).toEqual({
+      FEATURE_ENABLED: 'true',
+      BANNER_TEXT: 'sample lifecycle banner',
+      LIFECYCLE_API_URL: 'https://app.lifecycle.com/api/v1',
     });
   });
 });

--- a/src/server/lib/__tests__/comment.test.ts
+++ b/src/server/lib/__tests__/comment.test.ts
@@ -73,4 +73,17 @@ describe('CommentHelper.parseEnvironmentOverrides', () => {
       LIFECYCLE_API_URL: 'https://app.lifecycle.com/api/v1',
     });
   });
+
+  test('parses host and port values after the env key separator', () => {
+    const comment = [
+      'Status comment',
+      CommentParser.HEADER,
+      'ENV:URL:app-dev-0.lifecycle-grpc.example.com:443',
+      CommentParser.FOOTER,
+    ].join('\n');
+
+    expect(CommentHelper.parseEnvironmentOverrides(comment)).toEqual({
+      URL: 'app-dev-0.lifecycle-grpc.example.com:443',
+    });
+  });
 });

--- a/src/server/lib/__tests__/comment.test.ts
+++ b/src/server/lib/__tests__/comment.test.ts
@@ -28,18 +28,16 @@ describe('CommentHelper.parseEnvironmentOverrides', () => {
     const comment = [
       'Status comment',
       CommentParser.HEADER,
-      '// **Override Environment Variables**',
-      '// Add one override per line below.',
-      '// Only lines that start with ENV: are applied.',
-      '// Example boolean: ENV:FEATURE_ENABLED:true',
-      '// Example URL: ENV:LIFECYCLE_API_URL:https://lifecycle.example.com/api',
-      'ENV:LIFECYCLE_API_URL:https://lifecycle.example.com/api/v1',
+      '// Override Environment Variables (add one override per line below)',
+      '// Example ENV:FEATURE_ENABLED:true',
+      '// Example ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api',
+      'ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api/v1',
       'ENV:FEATURE_FLAGS.checkout:true',
       CommentParser.FOOTER,
     ].join('\n');
 
     expect(CommentHelper.parseEnvironmentOverrides(comment)).toEqual({
-      LIFECYCLE_API_URL: 'https://lifecycle.example.com/api/v1',
+      LIFECYCLE_API_URL: 'https://app.lifecycle.com/api/v1',
       FEATURE_FLAGS: {
         checkout: 'true',
       },

--- a/src/server/lib/__tests__/comment.test.ts
+++ b/src/server/lib/__tests__/comment.test.ts
@@ -28,7 +28,7 @@ describe('CommentHelper.parseEnvironmentOverrides', () => {
     const comment = [
       'Status comment',
       CommentParser.HEADER,
-      '// Override Environment Variables (add one override per line below)',
+      '// **Override Environment Variables (add one override per line below)**',
       '// Example ENV:FEATURE_ENABLED:true',
       '// Example ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api',
       'ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api/v1',

--- a/src/server/lib/__tests__/comment.test.ts
+++ b/src/server/lib/__tests__/comment.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommentHelper } from 'server/lib/comment';
+import { CommentParser } from 'shared/constants';
+
+jest.mock('server/lib/logger', () => ({
+  getLogger: jest.fn().mockReturnValue({
+    debug: jest.fn(),
+  }),
+}));
+
+describe('CommentHelper.parseEnvironmentOverrides', () => {
+  test('ignores commented examples and parses real env overrides', () => {
+    const comment = [
+      'Status comment',
+      CommentParser.HEADER,
+      '// **Override Environment Variables**',
+      '// Add one override per line below.',
+      '// Only lines that start with ENV: are applied.',
+      '// Example boolean: ENV:FEATURE_ENABLED:true',
+      '// Example URL: ENV:LIFECYCLE_API_URL:https://lifecycle.example.com/api',
+      'ENV:LIFECYCLE_API_URL:https://lifecycle.example.com/api/v1',
+      'ENV:FEATURE_FLAGS.checkout:true',
+      CommentParser.FOOTER,
+    ].join('\n');
+
+    expect(CommentHelper.parseEnvironmentOverrides(comment)).toEqual({
+      LIFECYCLE_API_URL: 'https://lifecycle.example.com/api/v1',
+      FEATURE_FLAGS: {
+        checkout: 'true',
+      },
+    });
+  });
+
+  test('preserves spaces in values while trimming leading whitespace', () => {
+    const comment = [
+      'Status comment',
+      CommentParser.HEADER,
+      '  ENV:BANNER_TEXT:sample lifecycle banner',
+      CommentParser.FOOTER,
+    ].join('\n');
+
+    expect(CommentHelper.parseEnvironmentOverrides(comment)).toEqual({
+      BANNER_TEXT: 'sample lifecycle banner',
+    });
+  });
+});

--- a/src/server/lib/comment.ts
+++ b/src/server/lib/comment.ts
@@ -73,8 +73,8 @@ export class CommentHelper {
     envLines.forEach((line) => {
       getLogger().debug(`Parsing environment override line=${line}`);
       const match = line.match(/ENV:([^:]*):(.*)/m);
-      const key = match[1];
-      const value = match[2];
+      const key = match[1].trim();
+      const value = match[2].trim();
       set(obj, key, value);
     });
     return obj;

--- a/src/server/lib/comment.ts
+++ b/src/server/lib/comment.ts
@@ -65,7 +65,7 @@ export class CommentHelper {
     const textToParse = comment.split(CommentParser.HEADER)[1].split(CommentParser.FOOTER)[0];
     const lines = textToParse
       .match(/[^\r\n]+/g) // Match by newline
-      .map((line) => line.replace(/ /g, '')); // Remove all whitespace
+      .map((line) => line.trim());
     const envLines = lines.filter((line) => {
       return line.startsWith('ENV:');
     });

--- a/src/server/services/activityStream.ts
+++ b/src/server/services/activityStream.ts
@@ -575,7 +575,7 @@ export default class ActivityStream extends BaseService {
     message += '\n\n// **UUID** *(Pick your own custom subdomain)*\n';
     message += `url: ${build.uuid}\n`;
 
-    message += '\n\n// Override Environment Variables (add one override per line below)\n';
+    message += '\n\n// **Override Environment Variables (add one override per line below)**\n';
     message += '// Example ENV:FEATURE_ENABLED:true\n';
     message += '// Example ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api\n';
     message += this.generateEnvBlockForBuild(build);

--- a/src/server/services/activityStream.ts
+++ b/src/server/services/activityStream.ts
@@ -576,8 +576,8 @@ export default class ActivityStream extends BaseService {
     message += `url: ${build.uuid}\n`;
 
     message += '\n\n// **Override Environment Variables (add one override per line below)**\n';
-    message += '// Example ENV:FEATURE_ENABLED:true\n';
-    message += '// Example ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api\n';
+    message += '// ENV:FEATURE_ENABLED:true\n';
+    message += '// ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api\n';
     message += this.generateEnvBlockForBuild(build);
 
     message += `\n\n${CommentParser.FOOTER}\n\n`;

--- a/src/server/services/activityStream.ts
+++ b/src/server/services/activityStream.ts
@@ -575,11 +575,9 @@ export default class ActivityStream extends BaseService {
     message += '\n\n// **UUID** *(Pick your own custom subdomain)*\n';
     message += `url: ${build.uuid}\n`;
 
-    message += '\n\n// **Override Environment Variables**\n';
-    message += '// Add one override per line below.\n';
-    message += '// Only lines that start with ENV: are applied.\n';
-    message += '// Example boolean: ENV:FEATURE_ENABLED:true\n';
-    message += '// Example URL: ENV:LIFECYCLE_API_URL:https://lifecycle.example.com/api\n';
+    message += '\n\n// Override Environment Variables (add one override per line below)\n';
+    message += '// Example ENV:FEATURE_ENABLED:true\n';
+    message += '// Example ENV:LIFECYCLE_API_URL:https://app.lifecycle.com/api\n';
     message += this.generateEnvBlockForBuild(build);
 
     message += `\n\n${CommentParser.FOOTER}\n\n`;

--- a/src/server/services/activityStream.ts
+++ b/src/server/services/activityStream.ts
@@ -575,8 +575,11 @@ export default class ActivityStream extends BaseService {
     message += '\n\n// **UUID** *(Pick your own custom subdomain)*\n';
     message += `url: ${build.uuid}\n`;
 
-    message +=
-      '\n\n// **Override Environment Variables:** *ENV:[KEY]:[VALUE]* --- Example *ENV:GORILLA_FUND:`https://gorillafund.org/`* 🦍 🤝 💪\n';
+    message += '\n\n// **Override Environment Variables**\n';
+    message += '// Add one override per line below.\n';
+    message += '// Only lines that start with ENV: are applied.\n';
+    message += '// Example boolean: ENV:FEATURE_ENABLED:true\n';
+    message += '// Example URL: ENV:LIFECYCLE_API_URL:https://lifecycle.example.com/api\n';
     message += this.generateEnvBlockForBuild(build);
 
     message += `\n\n${CommentParser.FOOTER}\n\n`;


### PR DESCRIPTION
## Summary
Improves the PR status comment guidance for environment overrides so the examples are clearer and safer to copy.

## What Changed
- replaced the single inline example with a short commented instruction block
- added two dummy examples: a boolean flag and a lifecycle-themed URL
- made the parser trim each line instead of removing all spaces, so values with spaces are preserved
- added focused tests proving commented examples are ignored and real `ENV:` lines still parse correctly

## Why
Users were getting confused by the existing example format, and the parser behavior around spaces was stricter than necessary.

## Validation
- `pnpm test -- --runTestsByPath src/server/lib/__tests__/comment.test.ts`