### PR TITLE
[codex] Fix image release artifact downloads

### DIFF
--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -162,6 +162,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
+          pattern: digests-*
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/buildkit-release.yaml
+++ b/.github/workflows/buildkit-release.yaml
@@ -158,6 +158,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
+          pattern: digests-*
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Summary
- scope `actions/download-artifact` to `digests-*` in `buildkit-release.yaml`
- apply the same fix to `base-release.yaml`

## Why
The BuildKit release workflow failed in `merge-and-push` because `actions/download-artifact@v4` downloaded all artifacts from the run, including the extra Buildx `.dockerbuild` artifacts. The existing `release.yaml` workflow already avoids this by filtering to the digest artifacts only.

## Impact
Both image release workflows now download only the digest artifacts they actually need for manifest creation.

## Validation
- `git diff --cached --check`
- inspected the failed Actions run `24483312834` and confirmed the artifact download failure mode