### PR TITLE
build(husky): replace npx with pnpm exec

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # Husky will pass the path to the temporary commit‐message file as $1
-npx commitlint --edit "$1"
+pnpm exec commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+pnpm exec lint-staged


### PR DESCRIPTION
  Goal: eliminate npx usage to reduce supply chain risk and ensure local, pinned tooling.
  Changes: updated Husky hooks to use pnpm exec for lint-staged and commitlint.