### PR TITLE
feat: add namespace metadata labels with pr info

### DIFF
--- a/src/server/lib/__tests__/namespaceMetadata.test.ts
+++ b/src/server/lib/__tests__/namespaceMetadata.test.ts
@@ -74,6 +74,10 @@ import { createOrUpdateNamespace } from '../kubernetes';
 describe('createOrUpdateNamespace metadata', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockReadNamespace.mockReset();
+    mockCreateNamespace.mockReset();
+    mockPatchNamespace.mockReset();
+    mockGetAllConfigs.mockReset();
     jest.useFakeTimers().setSystemTime(new Date('2026-04-16T12:00:00.000Z'));
     mockGetAllConfigs.mockResolvedValue({
       ttl_cleanup: {
@@ -163,6 +167,56 @@ describe('createOrUpdateNamespace metadata', () => {
       {
         headers: { 'Content-Type': 'application/json-patch+json' },
       }
+    );
+  });
+
+  it('sanitizes bot authors before writing lfc/author', async () => {
+    mockReadNamespace.mockRejectedValueOnce({ response: { statusCode: 404 } });
+    mockCreateNamespace.mockResolvedValue({});
+
+    await createOrUpdateNamespace({
+      name: 'env-bot123',
+      buildUUID: 'bot123',
+      staticEnv: false,
+      repo: 'example-org/example-repo',
+      pullRequestNumber: 77,
+      author: 'automation[bot]',
+    });
+
+    expect(mockCreateNamespace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          labels: expect.objectContaining({
+            'lfc/author': 'automation-bot',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('truncates long repository names to a Kubernetes-safe lfc/repo label', async () => {
+    mockReadNamespace.mockRejectedValueOnce({ response: { statusCode: 404 } });
+    mockCreateNamespace.mockResolvedValue({});
+
+    const longRepoName = 'example-repository-name-that-exceeds-the-kubernetes-label-limit-by-a-lot';
+
+    await createOrUpdateNamespace({
+      name: 'env-longrepo',
+      buildUUID: 'longrepo',
+      staticEnv: false,
+      repo: `example-org/${longRepoName}`,
+      pullRequestNumber: 91,
+      author: 'example-author',
+    });
+
+    expect(mockCreateNamespace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          labels: expect.objectContaining({
+            'lfc/repo': 'example-repository-name-that-exceeds-the-kubernetes-label-limit',
+          }),
+        }),
+      })
     );
   });
 });

--- a/src/server/lib/__tests__/namespaceMetadata.test.ts
+++ b/src/server/lib/__tests__/namespaceMetadata.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2026 Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var mockReadNamespace: jest.Mock;
+var mockCreateNamespace: jest.Mock;
+var mockPatchNamespace: jest.Mock;
+var mockGetAllConfigs: jest.Mock;
+
+jest.mock('@kubernetes/client-node', () => {
+  const actual = jest.requireActual('@kubernetes/client-node');
+
+  mockReadNamespace = jest.fn();
+  mockCreateNamespace = jest.fn();
+  mockPatchNamespace = jest.fn();
+
+  const coreClient = {
+    readNamespace: mockReadNamespace,
+    createNamespace: mockCreateNamespace,
+    patchNamespace: mockPatchNamespace,
+  };
+
+  return {
+    ...actual,
+    KubeConfig: jest.fn().mockImplementation(() => ({
+      loadFromDefault: jest.fn(),
+      makeApiClient: jest.fn().mockImplementation((client: unknown) => {
+        if (client === actual.CoreV1Api) {
+          return coreClient;
+        }
+
+        return {};
+      }),
+    })),
+  };
+});
+
+jest.mock('server/services/globalConfig', () => {
+  mockGetAllConfigs = jest.fn();
+
+  return {
+    __esModule: true,
+    default: {
+      getInstance: jest.fn(() => ({
+        getAllConfigs: mockGetAllConfigs,
+      })),
+    },
+  };
+});
+
+jest.mock('server/lib/logger', () => ({
+  getLogger: jest.fn(() => ({
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
+import { createOrUpdateNamespace } from '../kubernetes';
+
+describe('createOrUpdateNamespace metadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-16T12:00:00.000Z'));
+    mockGetAllConfigs.mockResolvedValue({
+      ttl_cleanup: {
+        inactivityDays: 7,
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('adds PR and repo labels when creating a namespace', async () => {
+    mockReadNamespace.mockRejectedValueOnce({ response: { statusCode: 404 } });
+    mockCreateNamespace.mockResolvedValue({});
+
+    await createOrUpdateNamespace({
+      name: 'env-abc123',
+      buildUUID: 'abc123',
+      staticEnv: false,
+      repo: 'example-org/example-repo',
+      pullRequestNumber: 2487,
+      author: 'example-author',
+    });
+
+    expect(mockCreateNamespace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          name: 'env-abc123',
+          labels: expect.objectContaining({
+            'lfc/uuid': 'abc123',
+            'lfc/type': 'ephemeral',
+            'lfc/org': 'example-org',
+            'lfc/repo': 'example-repo',
+            'lfc/pull-request': '2487',
+            'lfc/author': 'example-author',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('patches PR and repo labels onto an existing namespace', async () => {
+    mockReadNamespace
+      .mockResolvedValueOnce({ body: { metadata: { name: 'env-abc123', labels: {} } } })
+      .mockResolvedValueOnce({ body: { metadata: { name: 'env-abc123', labels: {} } } });
+    mockPatchNamespace.mockResolvedValue({});
+
+    await createOrUpdateNamespace({
+      name: 'env-abc123',
+      buildUUID: 'abc123',
+      staticEnv: false,
+      repo: 'example-org/example-repo',
+      pullRequestNumber: 2487,
+      author: 'example-author',
+    });
+
+    expect(mockPatchNamespace).toHaveBeenCalledWith(
+      'env-abc123',
+      expect.arrayContaining([
+        {
+          op: 'add',
+          path: '/metadata/labels/lfc~1org',
+          value: 'example-org',
+        },
+        {
+          op: 'add',
+          path: '/metadata/labels/lfc~1repo',
+          value: 'example-repo',
+        },
+        {
+          op: 'add',
+          path: '/metadata/labels/lfc~1pull-request',
+          value: '2487',
+        },
+        {
+          op: 'add',
+          path: '/metadata/labels/lfc~1author',
+          value: 'example-author',
+        },
+      ]),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        headers: { 'Content-Type': 'application/json-patch+json' },
+      }
+    );
+  });
+});

--- a/src/server/lib/kubernetes.ts
+++ b/src/server/lib/kubernetes.ts
@@ -77,6 +77,42 @@ async function getTTLConfig(_buildUUID: string): Promise<{ daysToExpire: number 
   return { daysToExpire };
 }
 
+type NamespaceMetadata = {
+  labels: Record<string, string>;
+};
+
+function buildNamespacePrMetadata({
+  repo,
+  pullRequestNumber,
+  author,
+}: {
+  repo?: string | null;
+  pullRequestNumber?: number | null;
+  author?: string | null;
+} = {}): NamespaceMetadata {
+  const labels: Record<string, string> = {};
+
+  if (repo) {
+    const [org, repoName] = repo.split('/');
+    if (org) {
+      labels['lfc/org'] = org;
+    }
+    if (repoName) {
+      labels['lfc/repo'] = repoName;
+    }
+  }
+
+  if (pullRequestNumber != null) {
+    labels['lfc/pull-request'] = String(pullRequestNumber);
+  }
+
+  if (author) {
+    labels['lfc/author'] = author;
+  }
+
+  return { labels };
+}
+
 /**
  * Generates TTL-related labels for namespace creation
  */
@@ -85,16 +121,24 @@ async function generateTTLLabels({
   staticEnv,
   ttl,
   buildUUID,
+  repo,
+  pullRequestNumber,
+  author,
 }: {
   uuid: string;
   staticEnv: boolean;
   ttl: boolean;
   buildUUID: string;
-}): Promise<{ labels: Record<string, string>; logMessage: string }> {
+  repo?: string | null;
+  pullRequestNumber?: number | null;
+  author?: string | null;
+}): Promise<NamespaceMetadata & { logMessage: string }> {
+  const metadata = buildNamespacePrMetadata({ repo, pullRequestNumber, author });
   const baseLabels: Record<string, string> = {
     'lfc/uuid': uuid,
     'lfc/type': staticEnv ? 'static' : 'ephemeral',
     'app.kubernetes.io/managed-by': 'lifecycle',
+    ...metadata.labels,
   };
 
   // Static or TTL disabled - only set enable flag
@@ -134,16 +178,28 @@ async function generateTTLPatch({
   staticEnv,
   ttl,
   buildUUID,
+  repo,
+  pullRequestNumber,
+  author,
 }: {
   uuid: string;
   staticEnv: boolean;
   ttl: boolean;
   buildUUID: string;
+  repo?: string | null;
+  pullRequestNumber?: number | null;
+  author?: string | null;
 }): Promise<{ patch: any[]; logMessage: string }> {
+  const metadata = buildNamespacePrMetadata({ repo, pullRequestNumber, author });
   const basePatch = [
     { op: 'add', path: '/metadata/labels/lfc~1uuid', value: uuid },
     { op: 'add', path: '/metadata/labels/lfc~1type', value: staticEnv ? 'static' : 'ephemeral' },
     { op: 'add', path: '/metadata/labels/app.kubernetes.io~1managed-by', value: 'lifecycle' },
+    ...Object.entries(metadata.labels).map(([key, value]) => ({
+      op: 'add',
+      path: `/metadata/labels/${key.replace(/\//g, '~1')}`,
+      value,
+    })),
   ];
 
   // TTL disabled - only update enable flag
@@ -206,11 +262,17 @@ export async function createOrUpdateNamespace({
   buildUUID,
   staticEnv,
   ttl = true,
+  repo,
+  pullRequestNumber,
+  author,
 }: {
   name: string;
   buildUUID: string;
   staticEnv: boolean;
   ttl?: boolean;
+  repo?: string | null;
+  pullRequestNumber?: number | null;
+  author?: string | null;
 }) {
   const kc = new k8s.KubeConfig();
   kc.loadFromDefault();
@@ -224,6 +286,9 @@ export async function createOrUpdateNamespace({
     staticEnv,
     ttl,
     buildUUID,
+    repo,
+    pullRequestNumber,
+    author,
   });
 
   getLogger({ namespace: name }).info(`Deploy: creating namespace ${logMessage}`);
@@ -243,6 +308,9 @@ export async function createOrUpdateNamespace({
       staticEnv,
       ttl: staticEnv ? false : ttl,
       buildUUID,
+      repo,
+      pullRequestNumber,
+      author,
     });
 
     await client.patchNamespace(name, patch, undefined, undefined, undefined, undefined, undefined, {

--- a/src/server/lib/kubernetes.ts
+++ b/src/server/lib/kubernetes.ts
@@ -33,6 +33,7 @@ import { staticEnvTolerations } from './helm/constants';
 import { parseSecretRefsFromEnv, SecretRefWithEnvKey } from './secretRefs';
 import { generateSecretName } from './kubernetes/externalSecret';
 import { buildLifecycleLabels } from 'server/lib/kubernetes/labels';
+import { normalizeKubernetesLabelValue } from 'server/lib/kubernetes/utils';
 
 interface VOLUME {
   name: string;
@@ -95,10 +96,10 @@ function buildNamespacePrMetadata({
   if (repo) {
     const [org, repoName] = repo.split('/');
     if (org) {
-      labels['lfc/org'] = org;
+      labels['lfc/org'] = normalizeKubernetesLabelValue(org);
     }
     if (repoName) {
-      labels['lfc/repo'] = repoName;
+      labels['lfc/repo'] = normalizeKubernetesLabelValue(repoName);
     }
   }
 
@@ -107,7 +108,7 @@ function buildNamespacePrMetadata({
   }
 
   if (author) {
-    labels['lfc/author'] = author;
+    labels['lfc/author'] = normalizeKubernetesLabelValue(author);
   }
 
   return { labels };

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -1443,7 +1443,14 @@ export default class BuildService extends BaseService {
         const { serviceAccount } = await GlobalConfigService.getInstance().getAllConfigs();
         const serviceAccountName = serviceAccount?.name || 'default';
         // create namespace and annotate the service account
-        await k8s.createOrUpdateNamespace({ name: build.namespace, buildUUID: build.uuid, staticEnv: build.isStatic });
+        await k8s.createOrUpdateNamespace({
+          name: build.namespace,
+          buildUUID: build.uuid,
+          staticEnv: build.isStatic,
+          repo: build.pullRequest?.fullName,
+          pullRequestNumber: build.pullRequest?.pullRequestNumber,
+          author: build.pullRequest?.githubLogin,
+        });
         await k8s.createOrUpdateServiceAccount({
           namespace: build.namespace,
           role: serviceAccount?.role,


### PR DESCRIPTION
## What changed
- add namespace labels for PR metadata during namespace create and update
- split repository metadata into `lfc/org` and `lfc/repo` labels
- add focused coverage for namespace metadata behavior using generic test data

## Why
- make it easier to query and debug Lifecycle namespaces directly with label selectors

## Before / After

Before:
```yaml
metadata:
  labels:
    app.kubernetes.io/managed-by: lifecycle
    lfc/uuid: <build-uuid>
    lfc/type: <static|ephemeral>
    lfc/ttl-enable: <true|false>
    # and TTL timestamp labels when enabled
```

After:
```yaml
metadata:
  labels:
    app.kubernetes.io/managed-by: lifecycle
    lfc/uuid: <build-uuid>
    lfc/type: <static|ephemeral>
    lfc/ttl-enable: <true|false>
    lfc/org: <repo-owner>
    lfc/repo: <repo-name>
    lfc/pull-request: <pr-number>
    lfc/author: <github-login>
    # and TTL timestamp labels when enabled
```

## Impact
- namespaces created or updated by Lifecycle now include `lfc/org`, `lfc/repo`, `lfc/pull-request`, and `lfc/author`

## Validation
- `pnpm exec jest src/server/lib/__tests__/namespaceMetadata.test.ts --runInBand`
- `pnpm exec jest src/server/services/__tests__/build.test.ts --runInBand`
