### PR TITLE
configurable agent session runtime

### DIFF
--- a/src/app/api/v2/ai/agent-config/route.ts
+++ b/src/app/api/v2/ai/agent-config/route.ts
@@ -110,7 +110,9 @@ const getHandler = async (req: NextRequest) => {
  *     description: >
  *       Updates one patchable global AI agent configuration section without replacing
  *       the rest of the configuration. Supported patch targets are additive rules and
- *       approval policy. This avoids revalidating unrelated provider/model settings.
+ *       approval policy. Approval policy updates replace that section with the provided
+ *       value, so omitting defaultMode or rules clears them. This avoids revalidating
+ *       unrelated provider/model settings.
  *     tags:
  *       - AI Agent Config
  *     operationId: patchGlobalAIAgentConfig

--- a/src/app/api/v2/ai/agent/sandbox-sessions/route.ts
+++ b/src/app/api/v2/ai/agent/sandbox-sessions/route.ts
@@ -389,6 +389,7 @@ const postHandler = async (req: NextRequest) => {
         workspaceEditorImage: runtimeConfig.workspaceEditorImage,
         workspaceGatewayImage: runtimeConfig.workspaceGatewayImage,
         nodeSelector: runtimeConfig.nodeSelector,
+        keepAttachedServicesOnSessionNode: runtimeConfig.keepAttachedServicesOnSessionNode,
         readiness: runtimeConfig.readiness,
         resources: runtimeConfig.resources,
       } as SandboxSessionLaunchJob,

--- a/src/app/api/v2/ai/agent/sessions/route.ts
+++ b/src/app/api/v2/ai/agent/sessions/route.ts
@@ -639,6 +639,7 @@ const postHandler = async (req: NextRequest) => {
       workspaceEditorImage: runtimeConfig.workspaceEditorImage,
       workspaceGatewayImage: runtimeConfig.workspaceGatewayImage,
       nodeSelector: runtimeConfig.nodeSelector,
+      keepAttachedServicesOnSessionNode: runtimeConfig.keepAttachedServicesOnSessionNode,
       readiness: mergeAgentSessionReadinessForServices(
         runtimeConfig.readiness,
         resolvedServices.map((service) => service.devConfig.agentSession?.readiness)

--- a/src/app/api/v2/ai/config/agent-session/effective/route.ts
+++ b/src/app/api/v2/ai/config/agent-session/effective/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NextRequest } from 'next/server';
+import { createApiHandler } from 'server/lib/createApiHandler';
+import { successResponse } from 'server/lib/response';
+import AgentSessionConfigService from 'server/services/agentSessionConfig';
+
+/**
+ * @openapi
+ * /api/v2/ai/config/agent-session/effective:
+ *   get:
+ *     summary: Get effective global Agent Session configuration
+ *     tags:
+ *       - Agent Session Config
+ *     operationId: getEffectiveGlobalAgentSessionConfig
+ *     responses:
+ *       '200':
+ *         description: Effective global Agent Session configuration
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetEffectiveGlobalAgentSessionConfigSuccessResponse'
+ */
+const getHandler = async (req: NextRequest) => {
+  const config = await AgentSessionConfigService.getInstance().getEffectiveConfig();
+  return successResponse(config, { status: 200 }, req);
+};
+
+export const GET = createApiHandler(getHandler);

--- a/src/app/api/v2/ai/config/agent-session/runtime/route.ts
+++ b/src/app/api/v2/ai/config/agent-session/runtime/route.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2026 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import JsonSchema from 'jsonschema';
+import { NextRequest } from 'next/server';
+import { createApiHandler } from 'server/lib/createApiHandler';
+import { errorResponse, successResponse } from 'server/lib/response';
+import { agentSessionRuntimeSettingsSchema } from 'server/lib/validation/agentSessionConfigSchemas';
+import { AgentSessionConfigValidationError } from 'server/lib/validation/agentSessionConfigValidator';
+import AgentSessionConfigService from 'server/services/agentSessionConfig';
+
+/**
+ * @openapi
+ * /api/v2/ai/config/agent-session/runtime:
+ *   get:
+ *     summary: Get global Agent Session runtime configuration
+ *     tags:
+ *       - Agent Session Config
+ *     operationId: getGlobalAgentSessionRuntimeConfig
+ *     responses:
+ *       '200':
+ *         description: Global Agent Session runtime configuration
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetGlobalAgentSessionRuntimeConfigSuccessResponse'
+ *   put:
+ *     summary: Update global Agent Session runtime configuration
+ *     tags:
+ *       - Agent Session Config
+ *     operationId: updateGlobalAgentSessionRuntimeConfig
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AgentSessionRuntimeSettings'
+ *     responses:
+ *       '200':
+ *         description: Updated global Agent Session runtime configuration
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetGlobalAgentSessionRuntimeConfigSuccessResponse'
+ *       '400':
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ */
+const getHandler = async (req: NextRequest) => {
+  const config = await AgentSessionConfigService.getInstance().getGlobalRuntimeConfig();
+  return successResponse(config, { status: 200 }, req);
+};
+
+const putHandler = async (req: NextRequest) => {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse(new Error('Invalid JSON in request body'), { status: 400 }, req);
+  }
+
+  const validator = new JsonSchema.Validator();
+  const result = validator.validate(body, agentSessionRuntimeSettingsSchema);
+  if (!result.valid) {
+    const messages = result.errors.map((entry) => entry.stack).join('; ');
+    return errorResponse(new Error(`Validation failed: ${messages}`), { status: 400 }, req);
+  }
+
+  try {
+    const config = await AgentSessionConfigService.getInstance().setGlobalRuntimeConfig(body as any);
+    return successResponse(config, { status: 200 }, req);
+  } catch (error) {
+    if (error instanceof AgentSessionConfigValidationError) {
+      return errorResponse(error, { status: 400 }, req);
+    }
+    throw error;
+  }
+};
+
+export const GET = createApiHandler(getHandler);
+export const PUT = createApiHandler(putHandler);

--- a/src/server/db/migrations/020_add_agent_session_same_node_default.ts
+++ b/src/server/db/migrations/020_add_agent_session_same_node_default.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+
+export const config = {
+  transaction: true,
+};
+
+const AGENT_SESSION_DEFAULTS_KEY = 'agentSessionDefaults';
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export async function up(knex: Knex): Promise<void> {
+  const hasPolicyColumn = await knex.schema.hasColumn('agent_sessions', 'keepAttachedServicesOnSessionNode');
+  if (!hasPolicyColumn) {
+    await knex.schema.alterTable('agent_sessions', (table) => {
+      table.boolean('keepAttachedServicesOnSessionNode').nullable();
+    });
+  }
+
+  const row = await knex('global_config').where('key', AGENT_SESSION_DEFAULTS_KEY).first();
+  const currentConfig = isObject(row?.config) ? row.config : {};
+  const currentScheduling = isObject(currentConfig.scheduling) ? currentConfig.scheduling : {};
+
+  if (typeof currentScheduling.keepAttachedServicesOnSessionNode === 'boolean') {
+    return;
+  }
+
+  const nextConfig = {
+    ...currentConfig,
+    scheduling: {
+      ...currentScheduling,
+      keepAttachedServicesOnSessionNode: true,
+    },
+  };
+
+  if (!row) {
+    await knex('global_config').insert({
+      key: AGENT_SESSION_DEFAULTS_KEY,
+      config: nextConfig,
+      createdAt: knex.fn.now(),
+      updatedAt: knex.fn.now(),
+      deletedAt: null,
+      description: 'Default configuration for agent session workspace runtime.',
+    });
+    return;
+  }
+
+  await knex('global_config').where('key', AGENT_SESSION_DEFAULTS_KEY).update({
+    config: nextConfig,
+    updatedAt: knex.fn.now(),
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const row = await knex('global_config').where('key', AGENT_SESSION_DEFAULTS_KEY).first();
+  const currentConfig = isObject(row?.config) ? row.config : {};
+  const currentScheduling = isObject(currentConfig.scheduling) ? currentConfig.scheduling : null;
+
+  if (currentScheduling && 'keepAttachedServicesOnSessionNode' in currentScheduling) {
+    const { keepAttachedServicesOnSessionNode: _ignored, ...restScheduling } = currentScheduling;
+    const { scheduling: _removedScheduling, ...restConfig } = currentConfig;
+
+    await knex('global_config')
+      .where('key', AGENT_SESSION_DEFAULTS_KEY)
+      .update({
+        config: {
+          ...restConfig,
+          ...(Object.keys(restScheduling).length > 0 ? { scheduling: restScheduling } : {}),
+        },
+        updatedAt: knex.fn.now(),
+      });
+  }
+
+  const hasPolicyColumn = await knex.schema.hasColumn('agent_sessions', 'keepAttachedServicesOnSessionNode');
+  if (hasPolicyColumn) {
+    await knex.schema.alterTable('agent_sessions', (table) => {
+      table.dropColumn('keepAttachedServicesOnSessionNode');
+    });
+  }
+}

--- a/src/server/jobs/agentSandboxSessionLaunch.ts
+++ b/src/server/jobs/agentSandboxSessionLaunch.ts
@@ -56,6 +56,7 @@ export async function processAgentSandboxSessionLaunch(job: Job<SandboxSessionLa
     workspaceEditorImage,
     workspaceGatewayImage,
     nodeSelector,
+    keepAttachedServicesOnSessionNode,
     readiness,
     resources,
   } = job.data;
@@ -83,6 +84,7 @@ export async function processAgentSandboxSessionLaunch(job: Job<SandboxSessionLa
       workspaceEditorImage,
       workspaceGatewayImage,
       nodeSelector,
+      keepAttachedServicesOnSessionNode,
       readiness,
       resources,
       onProgress: reportProgress,

--- a/src/server/lib/agentSession/__tests__/runtimeConfig.test.ts
+++ b/src/server/lib/agentSession/__tests__/runtimeConfig.test.ts
@@ -27,6 +27,10 @@ jest.mock('server/services/globalConfig', () => ({
 
 import {
   AgentSessionRuntimeConfigError,
+  DEFAULT_AGENT_SESSION_KEEP_ATTACHED_SERVICES_ON_SESSION_NODE,
+  DEFAULT_AGENT_SESSION_MAX_ITERATIONS,
+  DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_DISCOVERY_TIMEOUT_MS,
+  DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_EXECUTION_TIMEOUT_MS,
   mergeAgentSessionReadiness,
   mergeAgentSessionReadinessForServices,
   mergeAgentSessionResources,
@@ -77,6 +81,7 @@ const DEFAULT_RESOURCES = {
 
 function buildExpectedRuntimeConfig(overrides?: {
   nodeSelector?: Record<string, string>;
+  keepAttachedServicesOnSessionNode?: boolean;
   readiness?: typeof DEFAULT_READINESS;
   resources?: typeof DEFAULT_RESOURCES;
 }) {
@@ -85,6 +90,7 @@ function buildExpectedRuntimeConfig(overrides?: {
     workspaceEditorImage: 'codercom/code-server:4.98.2',
     workspaceGatewayImage: 'lifecycle-workspace:sha-123',
     nodeSelector: undefined,
+    keepAttachedServicesOnSessionNode: DEFAULT_AGENT_SESSION_KEEP_ATTACHED_SERVICES_ON_SESSION_NODE,
     readiness: DEFAULT_READINESS,
     resources: DEFAULT_RESOURCES,
     ...overrides,
@@ -113,6 +119,7 @@ describe('runtimeConfig', () => {
         workspaceImage: 'lifecycle-workspace:sha-123',
         workspaceEditorImage: 'codercom/code-server:4.98.2',
         scheduling: {
+          keepAttachedServicesOnSessionNode: false,
           nodeSelector: {
             'app-long': 'deployments-m7i',
             pool: 'agents',
@@ -127,6 +134,7 @@ describe('runtimeConfig', () => {
           'app-long': 'deployments-m7i',
           pool: 'agents',
         },
+        keepAttachedServicesOnSessionNode: false,
       })
     );
   });
@@ -231,6 +239,9 @@ describe('runtimeConfig', () => {
         controlPlane: {
           systemPrompt: 'You are Lifecycle Agent Session.',
           appendSystemPrompt: 'Use concise responses.',
+          maxIterations: 14,
+          workspaceToolDiscoveryTimeoutMs: 4500,
+          workspaceToolExecutionTimeoutMs: 22000,
         },
       },
     });
@@ -238,6 +249,9 @@ describe('runtimeConfig', () => {
     await expect(resolveAgentSessionControlPlaneConfig()).resolves.toEqual({
       systemPrompt: 'You are Lifecycle Agent Session.',
       appendSystemPrompt: 'Use concise responses.',
+      maxIterations: 14,
+      workspaceToolDiscoveryTimeoutMs: 4500,
+      workspaceToolExecutionTimeoutMs: 22000,
     });
   });
 
@@ -251,6 +265,9 @@ describe('runtimeConfig', () => {
         'If a tool call fails or a capability is unavailable, say that plainly and explain what failed.',
       appendSystemPrompt:
         'When a tool execution is not approved, do not retry the denied action. Use the denial reason as updated guidance and continue from there.',
+      maxIterations: DEFAULT_AGENT_SESSION_MAX_ITERATIONS,
+      workspaceToolDiscoveryTimeoutMs: DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_DISCOVERY_TIMEOUT_MS,
+      workspaceToolExecutionTimeoutMs: DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_EXECUTION_TIMEOUT_MS,
     });
   });
 

--- a/src/server/lib/agentSession/runtimeConfig.ts
+++ b/src/server/lib/agentSession/runtimeConfig.ts
@@ -29,6 +29,7 @@ export interface AgentSessionRuntimeConfig {
   workspaceEditorImage: string;
   workspaceGatewayImage: string;
   nodeSelector?: Record<string, string>;
+  keepAttachedServicesOnSessionNode: boolean;
   readiness: ResolvedAgentSessionReadinessConfig;
   resources: ResolvedAgentSessionResources;
 }
@@ -52,6 +53,9 @@ export interface ResolvedAgentSessionResources {
 export interface ResolvedAgentSessionControlPlaneConfig {
   systemPrompt?: string;
   appendSystemPrompt?: string;
+  maxIterations: number;
+  workspaceToolDiscoveryTimeoutMs: number;
+  workspaceToolExecutionTimeoutMs: number;
 }
 
 export const DEFAULT_AGENT_SESSION_CONTROL_PLANE_SYSTEM_PROMPT = [
@@ -64,6 +68,10 @@ export const DEFAULT_AGENT_SESSION_CONTROL_PLANE_SYSTEM_PROMPT = [
 
 export const DEFAULT_AGENT_SESSION_CONTROL_PLANE_APPEND_SYSTEM_PROMPT =
   'When a tool execution is not approved, do not retry the denied action. Use the denial reason as updated guidance and continue from there.';
+export const DEFAULT_AGENT_SESSION_MAX_ITERATIONS = 8;
+export const DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_DISCOVERY_TIMEOUT_MS = 3000;
+export const DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_EXECUTION_TIMEOUT_MS = 15000;
+export const DEFAULT_AGENT_SESSION_KEEP_ATTACHED_SERVICES_ON_SESSION_NODE = true;
 
 const DEFAULT_AGENT_READY_TIMEOUT_MS = 60000;
 const DEFAULT_AGENT_READY_POLL_MS = 2000;
@@ -117,6 +125,34 @@ function normalizeNonNegativeInteger(value: unknown): number | undefined {
   return undefined;
 }
 
+function normalizePositiveInteger(value: unknown): number | undefined {
+  const normalized = normalizeNonNegativeInteger(value);
+
+  if (normalized === undefined || normalized <= 0) {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+function normalizeBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') {
+      return true;
+    }
+    if (normalized === 'false') {
+      return false;
+    }
+  }
+
+  return undefined;
+}
+
 function normalizeResourceQuantityMap(values: unknown): Record<string, string> {
   if (!values || typeof values !== 'object' || Array.isArray(values)) {
     return {};
@@ -159,6 +195,13 @@ function normalizeNodeSelector(scheduling?: AgentSessionSchedulingConfig | null)
   );
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+export function resolveKeepAttachedServicesOnSessionNode(scheduling?: AgentSessionSchedulingConfig | null): boolean {
+  return (
+    normalizeBoolean(scheduling?.keepAttachedServicesOnSessionNode) ??
+    DEFAULT_AGENT_SESSION_KEEP_ATTACHED_SERVICES_ON_SESSION_NODE
+  );
 }
 
 function getDefaultReadinessConfig(): ResolvedAgentSessionReadinessConfig {
@@ -242,10 +285,21 @@ export function resolveAgentSessionControlPlaneConfigFromDefaults(
   const appendSystemPrompt =
     normalizeOptionalString(controlPlaneDefaults?.appendSystemPrompt) ||
     DEFAULT_AGENT_SESSION_CONTROL_PLANE_APPEND_SYSTEM_PROMPT;
+  const maxIterations =
+    normalizePositiveInteger(controlPlaneDefaults?.maxIterations) || DEFAULT_AGENT_SESSION_MAX_ITERATIONS;
+  const workspaceToolDiscoveryTimeoutMs =
+    normalizePositiveInteger(controlPlaneDefaults?.workspaceToolDiscoveryTimeoutMs) ||
+    DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_DISCOVERY_TIMEOUT_MS;
+  const workspaceToolExecutionTimeoutMs =
+    normalizePositiveInteger(controlPlaneDefaults?.workspaceToolExecutionTimeoutMs) ||
+    DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_EXECUTION_TIMEOUT_MS;
 
   return {
     systemPrompt,
     appendSystemPrompt,
+    maxIterations,
+    workspaceToolDiscoveryTimeoutMs,
+    workspaceToolExecutionTimeoutMs,
   };
 }
 
@@ -288,6 +342,7 @@ export async function resolveAgentSessionRuntimeConfig(): Promise<AgentSessionRu
     workspaceEditorImage,
     workspaceGatewayImage,
     nodeSelector: normalizeNodeSelector(agentSessionDefaults?.scheduling),
+    keepAttachedServicesOnSessionNode: resolveKeepAttachedServicesOnSessionNode(agentSessionDefaults?.scheduling),
     readiness: resolveAgentSessionReadinessFromDefaults(agentSessionDefaults?.readiness),
     resources: resolveAgentSessionResourcesFromDefaults(agentSessionDefaults?.resources),
   };

--- a/src/server/lib/validation/agentSessionConfigSchemas.ts
+++ b/src/server/lib/validation/agentSessionConfigSchemas.ts
@@ -24,14 +24,82 @@ const toolRuleSchema = {
   additionalProperties: false,
 };
 
+const positiveIntegerSchema = {
+  type: 'integer',
+  minimum: 1,
+};
+
+const nonNegativeIntegerSchema = {
+  type: 'integer',
+  minimum: 0,
+};
+
+const stringRecordSchema = {
+  type: 'object',
+  propertyNames: {
+    minLength: 1,
+  },
+  additionalProperties: {
+    type: 'string',
+    minLength: 1,
+  },
+};
+
+const resourceRequirementsSchema = {
+  type: 'object',
+  properties: {
+    requests: stringRecordSchema,
+    limits: stringRecordSchema,
+  },
+  additionalProperties: false,
+};
+
 export const agentSessionControlPlaneConfigSchema = {
   type: 'object',
   properties: {
     systemPrompt: { type: 'string', maxLength: 50000 },
     appendSystemPrompt: { type: 'string', maxLength: 50000 },
+    maxIterations: positiveIntegerSchema,
+    workspaceToolDiscoveryTimeoutMs: positiveIntegerSchema,
+    workspaceToolExecutionTimeoutMs: positiveIntegerSchema,
     toolRules: {
       type: 'array',
       items: toolRuleSchema,
+    },
+  },
+  additionalProperties: false,
+};
+
+export const agentSessionRuntimeSettingsSchema = {
+  type: 'object',
+  properties: {
+    workspaceImage: { type: 'string', minLength: 1, maxLength: 2048 },
+    workspaceEditorImage: { type: 'string', minLength: 1, maxLength: 2048 },
+    workspaceGatewayImage: { type: 'string', minLength: 1, maxLength: 2048 },
+    scheduling: {
+      type: 'object',
+      properties: {
+        nodeSelector: stringRecordSchema,
+        keepAttachedServicesOnSessionNode: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+    readiness: {
+      type: 'object',
+      properties: {
+        timeoutMs: nonNegativeIntegerSchema,
+        pollMs: nonNegativeIntegerSchema,
+      },
+      additionalProperties: false,
+    },
+    resources: {
+      type: 'object',
+      properties: {
+        workspace: resourceRequirementsSchema,
+        editor: resourceRequirementsSchema,
+        workspaceGateway: resourceRequirementsSchema,
+      },
+      additionalProperties: false,
     },
   },
   additionalProperties: false,

--- a/src/server/lib/validation/agentSessionConfigValidator.ts
+++ b/src/server/lib/validation/agentSessionConfigValidator.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { AgentSessionControlPlaneConfigValue } from 'server/services/types/agentSessionConfig';
+import type {
+  AgentSessionControlPlaneConfigValue,
+  AgentSessionRuntimeSettingsValue,
+} from 'server/services/types/agentSessionConfig';
 
 export class AgentSessionConfigValidationError extends Error {}
 
@@ -32,9 +35,61 @@ function validatePromptField(value: unknown, fieldName: string): void {
   }
 }
 
+function validatePositiveIntegerField(value: unknown, fieldName: string): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new AgentSessionConfigValidationError(`${fieldName} must be a positive integer.`);
+  }
+}
+
+function validateNonNegativeIntegerField(value: unknown, fieldName: string): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new AgentSessionConfigValidationError(`${fieldName} must be a non-negative integer.`);
+  }
+}
+
+function validateStringRecord(value: unknown, fieldName: string): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new AgentSessionConfigValidationError(`${fieldName} must be an object.`);
+  }
+
+  for (const [key, recordValue] of Object.entries(value)) {
+    if (!key.trim()) {
+      throw new AgentSessionConfigValidationError(`${fieldName} contains an empty key.`);
+    }
+    if (typeof recordValue !== 'string' || !recordValue.trim()) {
+      throw new AgentSessionConfigValidationError(`${fieldName}.${key} must be a non-empty string.`);
+    }
+  }
+}
+
+function validateBooleanField(value: unknown, fieldName: string): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value !== 'boolean') {
+    throw new AgentSessionConfigValidationError(`${fieldName} must be a boolean.`);
+  }
+}
+
 export function validateAgentSessionControlPlaneConfig(config: Partial<AgentSessionControlPlaneConfigValue>): void {
   validatePromptField(config.systemPrompt, 'systemPrompt');
   validatePromptField(config.appendSystemPrompt, 'appendSystemPrompt');
+  validatePositiveIntegerField(config.maxIterations, 'maxIterations');
+  validatePositiveIntegerField(config.workspaceToolDiscoveryTimeoutMs, 'workspaceToolDiscoveryTimeoutMs');
+  validatePositiveIntegerField(config.workspaceToolExecutionTimeoutMs, 'workspaceToolExecutionTimeoutMs');
 
   if (!config.toolRules) {
     return;
@@ -58,4 +113,23 @@ export function validateAgentSessionControlPlaneConfig(config: Partial<AgentSess
     }
     seen.add(rule.toolKey);
   }
+}
+
+export function validateAgentSessionRuntimeSettings(config: AgentSessionRuntimeSettingsValue): void {
+  validatePromptField(config.workspaceImage, 'workspaceImage');
+  validatePromptField(config.workspaceEditorImage, 'workspaceEditorImage');
+  validatePromptField(config.workspaceGatewayImage, 'workspaceGatewayImage');
+  validateStringRecord(config.scheduling?.nodeSelector, 'scheduling.nodeSelector');
+  validateBooleanField(
+    config.scheduling?.keepAttachedServicesOnSessionNode,
+    'scheduling.keepAttachedServicesOnSessionNode'
+  );
+  validateNonNegativeIntegerField(config.readiness?.timeoutMs, 'readiness.timeoutMs');
+  validateNonNegativeIntegerField(config.readiness?.pollMs, 'readiness.pollMs');
+  validateStringRecord(config.resources?.workspace?.requests, 'resources.workspace.requests');
+  validateStringRecord(config.resources?.workspace?.limits, 'resources.workspace.limits');
+  validateStringRecord(config.resources?.editor?.requests, 'resources.editor.requests');
+  validateStringRecord(config.resources?.editor?.limits, 'resources.editor.limits');
+  validateStringRecord(config.resources?.workspaceGateway?.requests, 'resources.workspaceGateway.requests');
+  validateStringRecord(config.resources?.workspaceGateway?.limits, 'resources.workspaceGateway.limits');
 }

--- a/src/server/lib/validation/agentSessionConfigValidator.ts
+++ b/src/server/lib/validation/agentSessionConfigValidator.ts
@@ -40,7 +40,7 @@ function validatePositiveIntegerField(value: unknown, fieldName: string): void {
     return;
   }
 
-  if (!Number.isInteger(value) || value <= 0) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
     throw new AgentSessionConfigValidationError(`${fieldName} must be a positive integer.`);
   }
 }
@@ -50,7 +50,7 @@ function validateNonNegativeIntegerField(value: unknown, fieldName: string): voi
     return;
   }
 
-  if (!Number.isInteger(value) || value < 0) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
     throw new AgentSessionConfigValidationError(`${fieldName} must be a non-negative integer.`);
   }
 }

--- a/src/server/models/AgentSession.ts
+++ b/src/server/models/AgentSession.ts
@@ -32,6 +32,7 @@ export default class AgentSession extends Model {
   pvcName!: string;
   model!: string;
   status!: 'starting' | 'active' | 'ended' | 'error';
+  keepAttachedServicesOnSessionNode!: boolean | null;
   lastActivity!: string;
   endedAt!: string | null;
   devModeSnapshots!: Record<string, DevModeResourceSnapshot>;
@@ -62,6 +63,7 @@ export default class AgentSession extends Model {
       pvcName: { type: 'string' },
       model: { type: 'string' },
       status: { type: 'string', enum: ['starting', 'active', 'ended', 'error'], default: 'starting' },
+      keepAttachedServicesOnSessionNode: { type: ['boolean', 'null'] },
       lastActivity: { type: 'string' },
       endedAt: { type: ['string', 'null'] },
       devModeSnapshots: { type: 'object', default: {} },

--- a/src/server/services/__tests__/agentSession.test.ts
+++ b/src/server/services/__tests__/agentSession.test.ts
@@ -789,6 +789,11 @@ describe('AgentSessionService', () => {
 
       await AgentSessionService.createSession(optsWithServices);
 
+      expect(mockSessionQuery.insertAndFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keepAttachedServicesOnSessionNode: true,
+        })
+      );
       expect(mockEnableDevMode).toHaveBeenCalledTimes(2);
       expect(mockEnableDevMode).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -812,6 +817,35 @@ describe('AgentSessionService', () => {
             '1': expect.any(Object),
             '2': expect.any(Object),
           }),
+        })
+      );
+    });
+
+    it('does not pin services to the session node when same-node placement is disabled', async () => {
+      const optsWithServices: CreateSessionOptions = {
+        ...baseOpts,
+        keepAttachedServicesOnSessionNode: false,
+        services: [
+          {
+            name: 'web',
+            deployId: 1,
+            resourceName: 'web-build-uuid',
+            devConfig: { image: 'node:20', command: 'pnpm dev' },
+          },
+        ],
+      };
+
+      await AgentSessionService.createSession(optsWithServices);
+
+      expect(mockSessionQuery.insertAndFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keepAttachedServicesOnSessionNode: false,
+        })
+      );
+      expect(mockEnableDevMode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deploymentName: 'web-build-uuid',
+          requiredNodeName: undefined,
         })
       );
     });
@@ -1235,6 +1269,197 @@ describe('AgentSessionService', () => {
           devModeSnapshots: expect.objectContaining({
             '11': expect.any(Object),
           }),
+        })
+      );
+    });
+
+    it('honors the session stored same-node policy when attaching services', async () => {
+      const globalConfigService = jest.requireMock('server/services/globalConfig').default;
+      globalConfigService.getInstance.mockReturnValueOnce({
+        getConfig: jest.fn().mockImplementation(async (key: string) => {
+          if (key === 'agentSessionDefaults') {
+            return {
+              scheduling: {
+                keepAttachedServicesOnSessionNode: false,
+              },
+            };
+          }
+
+          return null;
+        }),
+      });
+
+      mockSessionQuery.findOne.mockResolvedValue({
+        id: 321,
+        uuid: 'sess-1',
+        status: 'active',
+        buildUuid: 'build-123',
+        buildKind: 'environment',
+        namespace: 'test-ns',
+        podName: 'agent-aaaaaaaa',
+        pvcName: 'agent-pvc-aaaaaaaa',
+        keepAttachedServicesOnSessionNode: true,
+        workspaceRepos: [
+          {
+            repo: 'example-org/example-repo',
+            repoUrl: 'https://github.com/example-org/example-repo.git',
+            branch: 'feature/current',
+            mountPath: '/workspace',
+            primary: true,
+          },
+        ],
+        selectedServices: [],
+        devModeSnapshots: {},
+      });
+      (loadAgentSessionServiceCandidates as jest.Mock).mockResolvedValue([
+        {
+          name: 'web',
+          type: 'github',
+          deployId: 11,
+          devConfig: {
+            image: 'node:20',
+            command: 'pnpm dev',
+            installCommand: 'cd /workspace/apps/web && pnpm install',
+            workDir: '/workspace/apps/web',
+          },
+          repo: 'example-org/example-repo',
+          branch: 'feature/current',
+          revision: '0123456789abcdef0123456789abcdef01234567',
+          baseDeploy: {
+            id: 11,
+            uuid: 'web-build-uuid',
+          },
+        },
+      ]);
+
+      await AgentSessionService.attachServices('sess-1', ['web']);
+
+      expect(mockEnableDevMode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deploymentName: 'web-build-uuid',
+          requiredNodeName: 'agent-node-a',
+        })
+      );
+    });
+
+    it('honors a stored disabled same-node policy when attaching services', async () => {
+      mockSessionQuery.findOne.mockResolvedValue({
+        id: 321,
+        uuid: 'sess-1',
+        status: 'active',
+        buildUuid: 'build-123',
+        buildKind: 'environment',
+        namespace: 'test-ns',
+        podName: 'agent-aaaaaaaa',
+        pvcName: 'agent-pvc-aaaaaaaa',
+        keepAttachedServicesOnSessionNode: false,
+        workspaceRepos: [
+          {
+            repo: 'example-org/example-repo',
+            repoUrl: 'https://github.com/example-org/example-repo.git',
+            branch: 'feature/current',
+            mountPath: '/workspace',
+            primary: true,
+          },
+        ],
+        selectedServices: [],
+        devModeSnapshots: {},
+      });
+      (loadAgentSessionServiceCandidates as jest.Mock).mockResolvedValue([
+        {
+          name: 'web',
+          type: 'github',
+          deployId: 11,
+          devConfig: {
+            image: 'node:20',
+            command: 'pnpm dev',
+            installCommand: 'cd /workspace/apps/web && pnpm install',
+            workDir: '/workspace/apps/web',
+          },
+          repo: 'example-org/example-repo',
+          branch: 'feature/current',
+          revision: '0123456789abcdef0123456789abcdef01234567',
+          baseDeploy: {
+            id: 11,
+            uuid: 'web-build-uuid',
+          },
+        },
+      ]);
+
+      await AgentSessionService.attachServices('sess-1', ['web']);
+
+      expect(mockEnableDevMode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deploymentName: 'web-build-uuid',
+          requiredNodeName: undefined,
+        })
+      );
+    });
+
+    it('falls back to the current global placement policy for legacy sessions', async () => {
+      const globalConfigService = jest.requireMock('server/services/globalConfig').default;
+      globalConfigService.getInstance.mockReturnValueOnce({
+        getConfig: jest.fn().mockImplementation(async (key: string) => {
+          if (key === 'agentSessionDefaults') {
+            return {
+              scheduling: {
+                keepAttachedServicesOnSessionNode: false,
+              },
+            };
+          }
+
+          return null;
+        }),
+      });
+
+      mockSessionQuery.findOne.mockResolvedValue({
+        id: 321,
+        uuid: 'sess-1',
+        status: 'active',
+        buildUuid: 'build-123',
+        buildKind: 'environment',
+        namespace: 'test-ns',
+        podName: 'agent-aaaaaaaa',
+        pvcName: 'agent-pvc-aaaaaaaa',
+        workspaceRepos: [
+          {
+            repo: 'example-org/example-repo',
+            repoUrl: 'https://github.com/example-org/example-repo.git',
+            branch: 'feature/current',
+            mountPath: '/workspace',
+            primary: true,
+          },
+        ],
+        selectedServices: [],
+        devModeSnapshots: {},
+      });
+      (loadAgentSessionServiceCandidates as jest.Mock).mockResolvedValue([
+        {
+          name: 'web',
+          type: 'github',
+          deployId: 11,
+          devConfig: {
+            image: 'node:20',
+            command: 'pnpm dev',
+            installCommand: 'cd /workspace/apps/web && pnpm install',
+            workDir: '/workspace/apps/web',
+          },
+          repo: 'example-org/example-repo',
+          branch: 'feature/current',
+          revision: '0123456789abcdef0123456789abcdef01234567',
+          baseDeploy: {
+            id: 11,
+            uuid: 'web-build-uuid',
+          },
+        },
+      ]);
+
+      await AgentSessionService.attachServices('sess-1', ['web']);
+
+      expect(mockEnableDevMode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deploymentName: 'web-build-uuid',
+          requiredNodeName: undefined,
         })
       );
     });

--- a/src/server/services/__tests__/agentSessionConfig.test.ts
+++ b/src/server/services/__tests__/agentSessionConfig.test.ts
@@ -20,6 +20,19 @@ jest.mock('server/services/ai/mcp/config', () => ({
   })),
 }));
 
+const mockGlobalConfigGetConfig = jest.fn();
+const mockGlobalConfigSetConfig = jest.fn();
+
+jest.mock('server/services/globalConfig', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(() => ({
+      getConfig: (...args: unknown[]) => mockGlobalConfigGetConfig(...args),
+      setConfig: (...args: unknown[]) => mockGlobalConfigSetConfig(...args),
+    })),
+  },
+}));
+
 import AgentSessionConfigService from 'server/services/agentSessionConfig';
 import AgentPolicyService from 'server/services/agent/PolicyService';
 import { DEFAULT_AGENT_APPROVAL_POLICY } from 'server/services/agent/types';
@@ -37,6 +50,8 @@ function makeService() {
 describe('AgentSessionConfigService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGlobalConfigGetConfig.mockResolvedValue(undefined);
+    mockGlobalConfigSetConfig.mockResolvedValue(undefined);
   });
 
   it('lists only admin-visible sandbox tools in tool inventory', async () => {
@@ -68,5 +83,136 @@ describe('AgentSessionConfigService', () => {
     ]);
     expect(entries.find((entry) => entry.toolName === 'skills.list')).toBeUndefined();
     expect(entries.find((entry) => entry.toolName === 'session.get_workspace_state')).toBeUndefined();
+  });
+
+  it('merges repo control-plane numeric overrides over global defaults', async () => {
+    const service = makeService();
+
+    jest.spyOn(service, 'getGlobalConfig').mockResolvedValue({
+      systemPrompt: 'global prompt',
+      appendSystemPrompt: 'global append',
+      maxIterations: 8,
+      workspaceToolDiscoveryTimeoutMs: 3000,
+      workspaceToolExecutionTimeoutMs: 15000,
+      toolRules: [],
+    });
+    jest.spyOn(service, 'getRepoConfig').mockResolvedValue({
+      maxIterations: 12,
+      workspaceToolExecutionTimeoutMs: 45000,
+    });
+
+    await expect(service.getEffectiveConfig('example-org/example-repo')).resolves.toEqual({
+      systemPrompt: 'global prompt',
+      appendSystemPrompt: 'global append',
+      maxIterations: 12,
+      workspaceToolDiscoveryTimeoutMs: 3000,
+      workspaceToolExecutionTimeoutMs: 45000,
+      toolRules: [],
+    });
+  });
+
+  it('updates runtime settings without overwriting control-plane settings', async () => {
+    const service = makeService();
+
+    mockGlobalConfigGetConfig.mockResolvedValue({
+      controlPlane: {
+        systemPrompt: 'global prompt',
+      },
+      workspaceImage: 'old-workspace-image',
+    });
+
+    await expect(
+      service.setGlobalRuntimeConfig({
+        workspaceImage: 'workspace-image:v2',
+        workspaceEditorImage: 'editor-image:v2',
+        workspaceGatewayImage: 'gateway-image:v2',
+        scheduling: {
+          keepAttachedServicesOnSessionNode: false,
+          nodeSelector: {
+            pool: 'agents',
+          },
+        },
+        readiness: {
+          timeoutMs: 90000,
+          pollMs: 1500,
+        },
+        resources: {
+          workspace: {
+            requests: {
+              cpu: '1',
+            },
+          },
+        },
+      })
+    ).resolves.toEqual({
+      workspaceImage: 'workspace-image:v2',
+      workspaceEditorImage: 'editor-image:v2',
+      workspaceGatewayImage: 'gateway-image:v2',
+      scheduling: {
+        keepAttachedServicesOnSessionNode: false,
+        nodeSelector: {
+          pool: 'agents',
+        },
+      },
+      readiness: {
+        timeoutMs: 90000,
+        pollMs: 1500,
+      },
+      resources: {
+        workspace: {
+          requests: {
+            cpu: '1',
+          },
+        },
+      },
+    });
+
+    expect(mockGlobalConfigSetConfig).toHaveBeenCalledWith('agentSessionDefaults', {
+      controlPlane: {
+        systemPrompt: 'global prompt',
+      },
+      workspaceImage: 'workspace-image:v2',
+      workspaceEditorImage: 'editor-image:v2',
+      workspaceGatewayImage: 'gateway-image:v2',
+      scheduling: {
+        keepAttachedServicesOnSessionNode: false,
+        nodeSelector: {
+          pool: 'agents',
+        },
+      },
+      readiness: {
+        timeoutMs: 90000,
+        pollMs: 1500,
+      },
+      resources: {
+        workspace: {
+          requests: {
+            cpu: '1',
+          },
+        },
+      },
+    });
+  });
+
+  it('rejects runtime updates that remove the required workspace images', async () => {
+    const service = makeService();
+
+    mockGlobalConfigGetConfig.mockResolvedValue({
+      controlPlane: {
+        systemPrompt: 'global prompt',
+      },
+      workspaceImage: 'old-workspace-image',
+      workspaceEditorImage: 'old-editor-image',
+    });
+
+    await expect(
+      service.setGlobalRuntimeConfig({
+        readiness: {
+          timeoutMs: 90000,
+        },
+      })
+    ).rejects.toThrow('Missing required runtime fields: workspaceImage, workspaceEditorImage.');
+
+    expect(mockGlobalConfigSetConfig).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/aiAgentConfig.test.ts
+++ b/src/server/services/__tests__/aiAgentConfig.test.ts
@@ -115,7 +115,7 @@ describe('AIAgentConfigService', () => {
     expect(result.providers).toEqual(currentConfig.providers);
   });
 
-  it('updates global approval policy without revalidating unrelated provider defaults', async () => {
+  it('replaces global approval policy without revalidating unrelated provider defaults', async () => {
     const { service } = makeService();
     const currentConfig: AIAgentConfig = {
       enabled: true,
@@ -156,6 +156,7 @@ describe('AIAgentConfigService', () => {
     });
 
     const result = await service.updateGlobalApprovalPolicy({
+      defaultMode: 'require_approval',
       rules: {
         shell_exec: 'deny',
       },
@@ -179,6 +180,55 @@ describe('AIAgentConfigService', () => {
         shell_exec: 'deny',
       },
     });
+    expect(result.providers).toEqual(currentConfig.providers);
+  });
+
+  it('clears the global approval policy when given an empty replacement', async () => {
+    const { service } = makeService();
+    const currentConfig: AIAgentConfig = {
+      enabled: true,
+      providers: [
+        {
+          name: 'openai',
+          enabled: true,
+          apiKeyEnvVar: 'OPENAI_API_KEY',
+          models: [
+            {
+              id: 'gpt-5',
+              displayName: 'GPT-5',
+              enabled: true,
+              default: true,
+              maxTokens: 8192,
+            },
+          ],
+        },
+      ],
+      maxMessagesPerSession: 50,
+      sessionTTL: 3600,
+      approvalPolicy: {
+        defaultMode: 'deny',
+        rules: {
+          shell_exec: 'deny',
+        },
+      },
+    };
+
+    const setConfig = jest.fn().mockResolvedValue(undefined);
+    (GlobalConfigService.getInstance as jest.Mock).mockReturnValue({
+      getConfig: jest.fn().mockResolvedValue(currentConfig),
+      setConfig,
+    });
+
+    const result = await service.updateGlobalApprovalPolicy({});
+
+    expect(setConfig).toHaveBeenCalledWith(
+      'aiAgent',
+      expect.objectContaining({
+        providers: currentConfig.providers,
+      })
+    );
+    expect(setConfig.mock.calls[0]?.[1]).not.toHaveProperty('approvalPolicy');
+    expect(result.approvalPolicy).toBeUndefined();
     expect(result.providers).toEqual(currentConfig.providers);
   });
 

--- a/src/server/services/agent/CapabilityService.ts
+++ b/src/server/services/agent/CapabilityService.ts
@@ -43,6 +43,11 @@ type ToolExecutionHooks = {
   onFileChange?: (change: AgentFileChangeData) => Promise<void>;
 };
 
+type SessionWorkspaceGatewayTimeouts = {
+  discoveryTimeoutMs: number;
+  executionTimeoutMs: number;
+};
+
 function resolvePrimaryRepo(session: AgentSession): string | undefined {
   const primaryRepo = (session.workspaceRepos || []).find((repo) => repo.primary)?.repo;
   if (primaryRepo) {
@@ -65,7 +70,10 @@ function resolveSessionWorkspaceGatewayBaseUrl(session: AgentSession): string | 
   return `http://${session.podName}.${session.namespace}.svc.cluster.local:${SESSION_WORKSPACE_GATEWAY_PORT}`;
 }
 
-async function resolveSessionWorkspaceGatewayServer(session: AgentSession): Promise<ResolvedMcpServer | null> {
+async function resolveSessionWorkspaceGatewayServer(
+  session: AgentSession,
+  timeouts: SessionWorkspaceGatewayTimeouts
+): Promise<ResolvedMcpServer | null> {
   const baseUrl = resolveSessionWorkspaceGatewayBaseUrl(session);
   if (!baseUrl) {
     return null;
@@ -75,14 +83,14 @@ async function resolveSessionWorkspaceGatewayServer(session: AgentSession): Prom
   const client = new McpClientManager();
 
   try {
-    await client.connect({ type: 'http', url }, 3000);
-    const discoveredTools = await client.listTools();
+    await client.connect({ type: 'http', url }, timeouts.discoveryTimeoutMs);
+    const discoveredTools = await client.listTools(timeouts.discoveryTimeoutMs);
 
     return {
       slug: 'sandbox',
       name: 'Session Workspace',
       transport: { type: 'http', url },
-      timeout: 15000,
+      timeout: timeouts.executionTimeoutMs,
       defaultArgs: {},
       env: {},
       discoveredTools,
@@ -275,6 +283,8 @@ export default class AgentCapabilityService {
     repoFullName,
     userIdentity,
     approvalPolicy,
+    workspaceToolDiscoveryTimeoutMs,
+    workspaceToolExecutionTimeoutMs,
     hooks,
     toolRules,
   }: {
@@ -282,6 +292,8 @@ export default class AgentCapabilityService {
     repoFullName?: string;
     userIdentity: RequestUserIdentity;
     approvalPolicy: AgentApprovalPolicy;
+    workspaceToolDiscoveryTimeoutMs: number;
+    workspaceToolExecutionTimeoutMs: number;
     hooks?: ToolExecutionHooks;
     toolRules?: AgentSessionToolRule[];
   }): Promise<ToolSet> {
@@ -293,7 +305,10 @@ export default class AgentCapabilityService {
     const mcpConfigService = new McpConfigService();
     const [repoServers, workspaceGatewayServer] = await Promise.all([
       mcpConfigService.resolveServersForRepo(repoFullName, undefined, userIdentity),
-      resolveSessionWorkspaceGatewayServer(session),
+      resolveSessionWorkspaceGatewayServer(session, {
+        discoveryTimeoutMs: workspaceToolDiscoveryTimeoutMs,
+        executionTimeoutMs: workspaceToolExecutionTimeoutMs,
+      }),
     ]);
     const resolvedRepoServers = repoServers.flatMap((server) => {
       if (!usesSessionWorkspaceGatewayExecution(server.transport)) {

--- a/src/server/services/agent/RunExecutor.ts
+++ b/src/server/services/agent/RunExecutor.ts
@@ -168,6 +168,8 @@ export default class AgentRunExecutor {
       repoFullName,
       userIdentity,
       approvalPolicy,
+      workspaceToolDiscoveryTimeoutMs: effectiveSessionConfig.workspaceToolDiscoveryTimeoutMs,
+      workspaceToolExecutionTimeoutMs: effectiveSessionConfig.workspaceToolExecutionTimeoutMs,
       toolRules: effectiveSessionConfig.toolRules,
       hooks: {
         onToolStarted: async (audit) => {
@@ -238,7 +240,7 @@ export default class AgentRunExecutor {
       model,
       instructions: buildSystemPrompt([effectiveSessionConfig.systemPrompt, sessionPrompt]),
       tools,
-      stopWhen: stepCountIs(8),
+      stopWhen: stepCountIs(effectiveSessionConfig.maxIterations),
       onStepFinish: async (step) => {
         try {
           const usageSummary = observabilityTracker.updateFromStep({

--- a/src/server/services/agent/__tests__/CapabilityService.test.ts
+++ b/src/server/services/agent/__tests__/CapabilityService.test.ts
@@ -147,6 +147,8 @@ describe('AgentCapabilityService.buildToolSet', () => {
       repoFullName: 'example-org/example-repo',
       userIdentity,
       approvalPolicy: {} as any,
+      workspaceToolDiscoveryTimeoutMs: 4500,
+      workspaceToolExecutionTimeoutMs: 22000,
     });
 
     expect(mockConnect).toHaveBeenCalledWith(
@@ -154,8 +156,9 @@ describe('AgentCapabilityService.buildToolSet', () => {
         type: 'http',
         url: 'http://agent-123.env-sample.svc.cluster.local:13338/mcp',
       },
-      3000
+      4500
     );
+    expect(mockListTools).toHaveBeenCalledWith(4500);
 
     const tool = tools.mcp__figma__get_design_context as {
       execute: (input: Record<string, unknown>) => Promise<unknown>;
@@ -172,6 +175,33 @@ describe('AgentCapabilityService.buildToolSet', () => {
       30000
     );
     expect(mockCallTool).toHaveBeenCalledWith('get_design_context', {}, 30000);
+  });
+
+  it('uses the configured workspace execution timeout for sandbox tools', async () => {
+    const tools = await AgentCapabilityService.buildToolSet({
+      session,
+      repoFullName: 'example-org/example-repo',
+      userIdentity,
+      approvalPolicy: {} as any,
+      workspaceToolDiscoveryTimeoutMs: 4500,
+      workspaceToolExecutionTimeoutMs: 22000,
+    });
+
+    const tool = tools.mcp__sandbox__workspace_read_file as {
+      execute: (input: Record<string, unknown>) => Promise<unknown>;
+    };
+    expect(tool).toBeDefined();
+
+    await tool.execute({});
+
+    expect(mockConnect).toHaveBeenLastCalledWith(
+      {
+        type: 'http',
+        url: 'http://agent-123.env-sample.svc.cluster.local:13338/mcp',
+      },
+      22000
+    );
+    expect(mockCallTool).toHaveBeenCalledWith('workspace.read_file', {}, 22000);
   });
 
   it('omits session-pod stdio connectors when the sandbox gateway is unavailable', async () => {
@@ -191,6 +221,8 @@ describe('AgentCapabilityService.buildToolSet', () => {
       repoFullName: 'example-org/example-repo',
       userIdentity,
       approvalPolicy: {} as any,
+      workspaceToolDiscoveryTimeoutMs: 3000,
+      workspaceToolExecutionTimeoutMs: 15000,
     });
 
     expect(tools.mcp__figma__get_design_context).toBeUndefined();

--- a/src/server/services/agent/__tests__/RunExecutor.test.ts
+++ b/src/server/services/agent/__tests__/RunExecutor.test.ts
@@ -15,11 +15,12 @@
  */
 
 var mockToolLoopAgent: jest.Mock;
+var mockStepCountIs: jest.Mock;
 
 jest.mock('ai', () => ({
   __esModule: true,
   ToolLoopAgent: (mockToolLoopAgent = jest.fn().mockImplementation((config) => ({ config }))),
-  stepCountIs: jest.fn(() => 'stop-condition'),
+  stepCountIs: (mockStepCountIs = jest.fn(() => 'stop-condition')),
 }));
 
 const mockResolveSelection = jest.fn().mockResolvedValue({ provider: 'openai', modelId: 'gpt-5.4' });
@@ -70,6 +71,9 @@ const mockTouchActivity = jest.fn().mockResolvedValue(undefined);
 const mockGetEffectiveSessionConfig = jest.fn().mockResolvedValue({
   systemPrompt: 'DB prompt as stored',
   appendSystemPrompt: undefined,
+  maxIterations: 8,
+  workspaceToolDiscoveryTimeoutMs: 3000,
+  workspaceToolExecutionTimeoutMs: 15000,
   toolRules: [],
 });
 
@@ -163,6 +167,9 @@ describe('AgentRunExecutor', () => {
     mockGetEffectiveSessionConfig.mockResolvedValue({
       systemPrompt: 'DB prompt as stored',
       appendSystemPrompt: undefined,
+      maxIterations: 8,
+      workspaceToolDiscoveryTimeoutMs: 3000,
+      workspaceToolExecutionTimeoutMs: 15000,
       toolRules: [],
     });
     mockPendingActionFirst.mockResolvedValue(null);
@@ -182,6 +189,7 @@ describe('AgentRunExecutor', () => {
         instructions: 'DB prompt as stored\n\nAppend prompt',
       })
     );
+    expect(mockStepCountIs).toHaveBeenCalledWith(8);
   });
 
   it('correlates tool execution audit rows by toolCallId and touches session activity on step progress', async () => {
@@ -194,6 +202,12 @@ describe('AgentRunExecutor', () => {
 
     const toolSetArgs = mockBuildToolSet.mock.calls[0]?.[0];
     expect(toolSetArgs?.hooks).toBeDefined();
+    expect(toolSetArgs).toEqual(
+      expect.objectContaining({
+        workspaceToolDiscoveryTimeoutMs: 3000,
+        workspaceToolExecutionTimeoutMs: 15000,
+      })
+    );
 
     mockPendingActionFirst.mockResolvedValue({
       id: 55,
@@ -249,5 +263,31 @@ describe('AgentRunExecutor', () => {
     });
 
     expect(mockTouchActivity).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('uses configured max iterations and workspace tool timeouts', async () => {
+    mockGetEffectiveSessionConfig.mockResolvedValue({
+      systemPrompt: 'DB prompt as stored',
+      appendSystemPrompt: undefined,
+      maxIterations: 14,
+      workspaceToolDiscoveryTimeoutMs: 4500,
+      workspaceToolExecutionTimeoutMs: 22000,
+      toolRules: [],
+    });
+
+    await AgentRunExecutor.execute({
+      session: { uuid: 'sess-1' } as any,
+      thread: { id: 7, uuid: 'thread-1' } as any,
+      userIdentity: { userId: 'sample-user' } as any,
+      messages: [],
+    });
+
+    expect(mockStepCountIs).toHaveBeenCalledWith(14);
+    expect(mockBuildToolSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceToolDiscoveryTimeoutMs: 4500,
+        workspaceToolExecutionTimeoutMs: 22000,
+      })
+    );
   });
 });

--- a/src/server/services/agentSandboxSession.ts
+++ b/src/server/services/agentSandboxSession.ts
@@ -138,6 +138,7 @@ export interface LaunchSandboxSessionOptions {
   workspaceEditorImage?: string;
   workspaceGatewayImage?: string;
   nodeSelector?: Record<string, string>;
+  keepAttachedServicesOnSessionNode?: boolean;
   readiness: ResolvedAgentSessionReadinessConfig;
   resources: ResolvedAgentSessionResources;
   onProgress?: (stage: SandboxLaunchStage, message: string) => Promise<void> | void;
@@ -268,6 +269,7 @@ export default class AgentSandboxSessionService extends BaseService {
         workspaceEditorImage: opts.workspaceEditorImage,
         workspaceGatewayImage: opts.workspaceGatewayImage,
         nodeSelector: opts.nodeSelector,
+        keepAttachedServicesOnSessionNode: opts.keepAttachedServicesOnSessionNode,
         readiness: mergeAgentSessionReadinessForServices(
           opts.readiness,
           selectedServices.map((service) => service.devConfig.agentSession?.readiness)

--- a/src/server/services/agentSession.ts
+++ b/src/server/services/agentSession.ts
@@ -45,6 +45,7 @@ import { extractContextForQueue, getLogger } from 'server/lib/logger';
 import { BuildKind, FeatureFlags } from 'shared/constants';
 import type { RequestUserIdentity } from 'server/lib/get-user';
 import {
+  resolveKeepAttachedServicesOnSessionNode,
   type ResolvedAgentSessionReadinessConfig,
   type ResolvedAgentSessionResources,
 } from 'server/lib/agentSession/runtimeConfig';
@@ -78,6 +79,7 @@ import {
 } from 'server/lib/agentSession/startupFailureState';
 import { BuildEnvironmentVariables } from 'server/lib/buildEnvVariables';
 import { McpConfigService } from 'server/services/ai/mcp/config';
+import GlobalConfigService from './globalConfig';
 import {
   SESSION_POD_MCP_CONFIG_SECRET_KEY,
   serializeSessionWorkspaceGatewayServers,
@@ -220,6 +222,20 @@ async function resolveAgentPodNodeName(namespace: string, podName: string): Prom
   const response = await coreApi.readNamespacedPod(podName, namespace);
 
   return response.body.spec?.nodeName || null;
+}
+
+async function resolveSessionAttachmentPlacementPolicy(
+  session: Pick<AgentSession, 'keepAttachedServicesOnSessionNode'>
+): Promise<boolean> {
+  if (typeof session.keepAttachedServicesOnSessionNode === 'boolean') {
+    return session.keepAttachedServicesOnSessionNode;
+  }
+
+  const agentSessionDefaults = (await GlobalConfigService.getInstance().getConfig('agentSessionDefaults')) as
+    | { scheduling?: { keepAttachedServicesOnSessionNode?: boolean | null } }
+    | undefined;
+
+  return resolveKeepAttachedServicesOnSessionNode(agentSessionDefaults?.scheduling);
 }
 
 function getExecExitCode(status: any): number | null {
@@ -517,6 +533,7 @@ export interface CreateSessionOptions {
   workspaceEditorImage?: string;
   workspaceGatewayImage?: string;
   nodeSelector?: Record<string, string>;
+  keepAttachedServicesOnSessionNode?: boolean;
   readiness?: ResolvedAgentSessionReadinessConfig;
   resources?: ResolvedAgentSessionResources;
 }
@@ -789,6 +806,8 @@ export default class AgentSessionService {
     );
 
     try {
+      const keepAttachedServicesOnSessionNode = opts.keepAttachedServicesOnSessionNode !== false;
+
       session = await AgentSession.query().insertAndFetch({
         uuid: sessionUuid,
         buildUuid: opts.buildUuid || null,
@@ -800,6 +819,7 @@ export default class AgentSessionService {
         pvcName,
         model: resolvedModelId,
         status: 'starting',
+        keepAttachedServicesOnSessionNode,
         devModeSnapshots,
         forwardedAgentSecretProviders: forwardedAgentEnv.secretProviders,
         workspaceRepos,
@@ -858,7 +878,7 @@ export default class AgentSessionService {
       });
       const agentNodeName = workspacePod.spec?.nodeName || null;
 
-      if ((resolvedServices || []).length > 0 && !agentNodeName) {
+      if ((resolvedServices || []).length > 0 && keepAttachedServicesOnSessionNode && !agentNodeName) {
         throw new Error(`Session workspace pod ${podName} did not report a scheduled node`);
       }
 
@@ -871,7 +891,7 @@ export default class AgentSessionService {
           serviceName: resourceName,
           pvcName,
           devConfig: svc.devConfig,
-          requiredNodeName: agentNodeName || undefined,
+          requiredNodeName: keepAttachedServicesOnSessionNode ? agentNodeName || undefined : undefined,
         });
         mutatedDeploys.push(svc.deployId);
         devModeSnapshots[String(svc.deployId)] = snapshot;
@@ -1225,9 +1245,12 @@ export default class AgentSessionService {
       );
     }
 
-    const agentNodeName = await resolveAgentPodNodeName(session.namespace, session.podName);
+    const keepAttachedServicesOnSessionNode = await resolveSessionAttachmentPlacementPolicy(session);
+    const agentNodeName = keepAttachedServicesOnSessionNode
+      ? await resolveAgentPodNodeName(session.namespace, session.podName)
+      : null;
 
-    if (!agentNodeName) {
+    if (keepAttachedServicesOnSessionNode && !agentNodeName) {
       throw new Error(`Session workspace pod ${session.podName} did not report a scheduled node`);
     }
 
@@ -1244,7 +1267,7 @@ export default class AgentSessionService {
           serviceName: resourceName,
           pvcName: session.pvcName,
           devConfig: service.devConfig,
-          requiredNodeName: agentNodeName,
+          requiredNodeName: keepAttachedServicesOnSessionNode ? agentNodeName : undefined,
         });
 
         mutatedDeploys.push(service.deployId);

--- a/src/server/services/agentSessionConfig.ts
+++ b/src/server/services/agentSessionConfig.ts
@@ -19,9 +19,14 @@ import McpServerConfig from 'server/models/McpServerConfig';
 import UserMcpConnection from 'server/models/UserMcpConnection';
 import GlobalConfigService from './globalConfig';
 import { normalizeRepoFullName } from 'server/lib/normalizeRepoFullName';
-import { validateAgentSessionControlPlaneConfig } from 'server/lib/validation/agentSessionConfigValidator';
+import {
+  AgentSessionConfigValidationError,
+  validateAgentSessionControlPlaneConfig,
+  validateAgentSessionRuntimeSettings,
+} from 'server/lib/validation/agentSessionConfigValidator';
 import type {
   AgentSessionControlPlaneConfigValue,
+  AgentSessionRuntimeSettingsValue,
   AgentSessionToolInventoryEntry,
   AgentSessionToolRule,
   AgentSessionToolRuleSelection,
@@ -31,6 +36,9 @@ import type { GlobalConfig, AgentSessionDefaults } from './types/globalConfig';
 import {
   DEFAULT_AGENT_SESSION_CONTROL_PLANE_APPEND_SYSTEM_PROMPT,
   DEFAULT_AGENT_SESSION_CONTROL_PLANE_SYSTEM_PROMPT,
+  DEFAULT_AGENT_SESSION_MAX_ITERATIONS,
+  DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_DISCOVERY_TIMEOUT_MS,
+  DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_EXECUTION_TIMEOUT_MS,
 } from 'server/lib/agentSession/runtimeConfig';
 import { McpConfigService } from 'server/services/ai/mcp/config';
 import { normalizeAuthConfig, requiresUserConnection } from 'server/services/ai/mcp/connectionConfig';
@@ -44,6 +52,105 @@ import {
 
 function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeNonNegativeInteger(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isInteger(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') {
+      return true;
+    }
+    if (normalized === 'false') {
+      return false;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const normalized = Object.fromEntries(
+    Object.entries(value)
+      .filter(
+        ([key, entryValue]) =>
+          typeof key === 'string' && key.trim() && typeof entryValue === 'string' && entryValue.trim()
+      )
+      .map(([key, entryValue]) => [key.trim(), entryValue.trim()])
+  );
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeResourceRequirements(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const requests = normalizeStringRecord((value as { requests?: unknown }).requests);
+  const limits = normalizeStringRecord((value as { limits?: unknown }).limits);
+
+  if (!requests && !limits) {
+    return undefined;
+  }
+
+  return {
+    ...(requests ? { requests } : {}),
+    ...(limits ? { limits } : {}),
+  };
+}
+
+function validateRequiredRuntimeImages(config: Partial<GlobalConfig['agentSessionDefaults']>): void {
+  const missingFields: string[] = [];
+
+  if (!normalizeOptionalString(config.workspaceImage)) {
+    missingFields.push('workspaceImage');
+  }
+
+  if (!normalizeOptionalString(config.workspaceEditorImage)) {
+    missingFields.push('workspaceEditorImage');
+  }
+
+  if (missingFields.length > 0) {
+    throw new AgentSessionConfigValidationError(`Missing required runtime fields: ${missingFields.join(', ')}.`);
+  }
 }
 
 function normalizeToolRules(value: unknown): AgentSessionToolRule[] {
@@ -76,7 +183,81 @@ function normalizeControlPlaneConfig(value: unknown): AgentSessionControlPlaneCo
   return {
     systemPrompt: normalizeOptionalString((value as { systemPrompt?: unknown }).systemPrompt),
     appendSystemPrompt: normalizeOptionalString((value as { appendSystemPrompt?: unknown }).appendSystemPrompt),
+    maxIterations: normalizePositiveInteger((value as { maxIterations?: unknown }).maxIterations),
+    workspaceToolDiscoveryTimeoutMs: normalizePositiveInteger(
+      (value as { workspaceToolDiscoveryTimeoutMs?: unknown }).workspaceToolDiscoveryTimeoutMs
+    ),
+    workspaceToolExecutionTimeoutMs: normalizePositiveInteger(
+      (value as { workspaceToolExecutionTimeoutMs?: unknown }).workspaceToolExecutionTimeoutMs
+    ),
     toolRules: normalizeToolRules((value as { toolRules?: unknown }).toolRules),
+  };
+}
+
+function normalizeRuntimeSettings(value: unknown): AgentSessionRuntimeSettingsValue {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const workspaceImage = normalizeOptionalString((value as { workspaceImage?: unknown }).workspaceImage);
+  const workspaceEditorImage = normalizeOptionalString(
+    (value as { workspaceEditorImage?: unknown }).workspaceEditorImage
+  );
+  const workspaceGatewayImage = normalizeOptionalString(
+    (value as { workspaceGatewayImage?: unknown }).workspaceGatewayImage
+  );
+  const nodeSelector = normalizeStringRecord(
+    (value as { scheduling?: { nodeSelector?: unknown } }).scheduling?.nodeSelector
+  );
+  const keepAttachedServicesOnSessionNode = normalizeBoolean(
+    (value as { scheduling?: { keepAttachedServicesOnSessionNode?: unknown } }).scheduling
+      ?.keepAttachedServicesOnSessionNode
+  );
+  const readinessTimeoutMs = normalizeNonNegativeInteger(
+    (value as { readiness?: { timeoutMs?: unknown } }).readiness?.timeoutMs
+  );
+  const readinessPollMs = normalizeNonNegativeInteger(
+    (value as { readiness?: { pollMs?: unknown } }).readiness?.pollMs
+  );
+  const workspaceResources = normalizeResourceRequirements(
+    (value as { resources?: { workspace?: unknown } }).resources?.workspace
+  );
+  const editorResources = normalizeResourceRequirements(
+    (value as { resources?: { editor?: unknown } }).resources?.editor
+  );
+  const workspaceGatewayResources = normalizeResourceRequirements(
+    (value as { resources?: { workspaceGateway?: unknown } }).resources?.workspaceGateway
+  );
+
+  return {
+    ...(workspaceImage ? { workspaceImage } : {}),
+    ...(workspaceEditorImage ? { workspaceEditorImage } : {}),
+    ...(workspaceGatewayImage ? { workspaceGatewayImage } : {}),
+    ...(nodeSelector || keepAttachedServicesOnSessionNode !== undefined
+      ? {
+          scheduling: {
+            ...(nodeSelector ? { nodeSelector } : {}),
+            ...(keepAttachedServicesOnSessionNode !== undefined ? { keepAttachedServicesOnSessionNode } : {}),
+          },
+        }
+      : {}),
+    ...(readinessTimeoutMs !== undefined || readinessPollMs !== undefined
+      ? {
+          readiness: {
+            ...(readinessTimeoutMs !== undefined ? { timeoutMs: readinessTimeoutMs } : {}),
+            ...(readinessPollMs !== undefined ? { pollMs: readinessPollMs } : {}),
+          },
+        }
+      : {}),
+    ...(workspaceResources || editorResources || workspaceGatewayResources
+      ? {
+          resources: {
+            ...(workspaceResources ? { workspace: workspaceResources } : {}),
+            ...(editorResources ? { editor: editorResources } : {}),
+            ...(workspaceGatewayResources ? { workspaceGateway: workspaceGatewayResources } : {}),
+          },
+        }
+      : {}),
   };
 }
 
@@ -103,6 +284,9 @@ function hasConfigValues(config: Partial<AgentSessionControlPlaneConfigValue>): 
   return Boolean(
     normalizeOptionalString(config.systemPrompt) ||
       normalizeOptionalString(config.appendSystemPrompt) ||
+      normalizePositiveInteger(config.maxIterations) ||
+      normalizePositiveInteger(config.workspaceToolDiscoveryTimeoutMs) ||
+      normalizePositiveInteger(config.workspaceToolExecutionTimeoutMs) ||
       (config.toolRules && config.toolRules.length > 0)
   );
 }
@@ -136,6 +320,14 @@ export default class AgentSessionConfigService extends BaseService {
     return normalizeControlPlaneConfig(defaults?.controlPlane);
   }
 
+  async getGlobalRuntimeConfig(): Promise<AgentSessionRuntimeSettingsValue> {
+    const defaults = (await GlobalConfigService.getInstance().getConfig('agentSessionDefaults')) as
+      | AgentSessionDefaults
+      | undefined;
+
+    return normalizeRuntimeSettings(defaults);
+  }
+
   async setGlobalConfig(config: AgentSessionControlPlaneConfigValue): Promise<AgentSessionControlPlaneConfigValue> {
     const normalized = normalizeControlPlaneConfig(config);
     validateAgentSessionControlPlaneConfig(normalized);
@@ -146,6 +338,48 @@ export default class AgentSessionConfigService extends BaseService {
       ...currentDefaults,
       controlPlane: normalized,
     };
+
+    await GlobalConfigService.getInstance().setConfig('agentSessionDefaults', nextDefaults);
+    return normalized;
+  }
+
+  async setGlobalRuntimeConfig(config: AgentSessionRuntimeSettingsValue): Promise<AgentSessionRuntimeSettingsValue> {
+    const normalized = normalizeRuntimeSettings(config);
+    validateAgentSessionRuntimeSettings(normalized);
+
+    const currentDefaults = ((await GlobalConfigService.getInstance().getConfig('agentSessionDefaults')) ||
+      {}) as Partial<GlobalConfig['agentSessionDefaults']>;
+    const nextDefaults: Partial<GlobalConfig['agentSessionDefaults']> = {
+      ...currentDefaults,
+    };
+
+    delete nextDefaults.workspaceImage;
+    delete nextDefaults.workspaceEditorImage;
+    delete nextDefaults.workspaceGatewayImage;
+    delete nextDefaults.scheduling;
+    delete nextDefaults.readiness;
+    delete nextDefaults.resources;
+
+    if (normalized.workspaceImage) {
+      nextDefaults.workspaceImage = normalized.workspaceImage;
+    }
+    if (normalized.workspaceEditorImage) {
+      nextDefaults.workspaceEditorImage = normalized.workspaceEditorImage;
+    }
+    if (normalized.workspaceGatewayImage) {
+      nextDefaults.workspaceGatewayImage = normalized.workspaceGatewayImage;
+    }
+    if (normalized.scheduling) {
+      nextDefaults.scheduling = normalized.scheduling;
+    }
+    if (normalized.readiness) {
+      nextDefaults.readiness = normalized.readiness;
+    }
+    if (normalized.resources) {
+      nextDefaults.resources = normalized.resources;
+    }
+
+    validateRequiredRuntimeImages(nextDefaults);
 
     await GlobalConfigService.getInstance().setConfig('agentSessionDefaults', nextDefaults);
     return normalized;
@@ -218,6 +452,18 @@ export default class AgentSessionConfigService extends BaseService {
         normalizeOptionalString(repoConfig?.appendSystemPrompt) ||
         normalizeOptionalString(globalConfig.appendSystemPrompt) ||
         DEFAULT_AGENT_SESSION_CONTROL_PLANE_APPEND_SYSTEM_PROMPT,
+      maxIterations:
+        normalizePositiveInteger(repoConfig?.maxIterations) ||
+        normalizePositiveInteger(globalConfig.maxIterations) ||
+        DEFAULT_AGENT_SESSION_MAX_ITERATIONS,
+      workspaceToolDiscoveryTimeoutMs:
+        normalizePositiveInteger(repoConfig?.workspaceToolDiscoveryTimeoutMs) ||
+        normalizePositiveInteger(globalConfig.workspaceToolDiscoveryTimeoutMs) ||
+        DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_DISCOVERY_TIMEOUT_MS,
+      workspaceToolExecutionTimeoutMs:
+        normalizePositiveInteger(repoConfig?.workspaceToolExecutionTimeoutMs) ||
+        normalizePositiveInteger(globalConfig.workspaceToolExecutionTimeoutMs) ||
+        DEFAULT_AGENT_SESSION_WORKSPACE_TOOL_EXECUTION_TIMEOUT_MS,
       toolRules: mergeToolRules(globalConfig.toolRules || [], repoConfig?.toolRules || []),
     };
   }

--- a/src/server/services/ai/mcp/__tests__/oauthProvider.test.ts
+++ b/src/server/services/ai/mcp/__tests__/oauthProvider.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2026 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PersistentOAuthClientProvider } from '../oauthProvider';
+
+describe('PersistentOAuthClientProvider', () => {
+  it('includes a valid client URI in dynamic registration metadata', () => {
+    const provider = new PersistentOAuthClientProvider({
+      userId: 'sample-user',
+      ownerGithubUsername: 'sample-user',
+      scope: 'global',
+      slug: 'sample-oauth',
+      definitionFingerprint: 'sample-definition-fingerprint',
+      authConfig: {
+        mode: 'oauth',
+        provider: 'generic-oauth2.1',
+        scope: 'sample.read',
+        clientName: 'Sample MCP',
+      },
+      redirectUrl: 'https://app.example.com/api/v2/ai/agent/mcp-connections/sample-oauth/oauth/callback',
+      interactive: false,
+    });
+
+    expect(provider.clientMetadata).toEqual({
+      redirect_uris: ['https://app.example.com/api/v2/ai/agent/mcp-connections/sample-oauth/oauth/callback'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      client_name: 'Sample MCP',
+      client_uri: 'https://app.example.com',
+      scope: 'sample.read',
+    });
+  });
+});

--- a/src/server/services/ai/mcp/oauthProvider.ts
+++ b/src/server/services/ai/mcp/oauthProvider.ts
@@ -65,6 +65,7 @@ export class PersistentOAuthClientProvider implements OAuthClientProvider {
       grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
       client_name: this.options.authConfig.clientName || `${this.options.slug} MCP`,
+      client_uri: new URL(this.redirectUrl).origin,
       scope: this.options.authConfig.scope,
     };
   }

--- a/src/server/services/aiAgentConfig.ts
+++ b/src/server/services/aiAgentConfig.ts
@@ -192,11 +192,7 @@ export default class AIAgentConfigService extends BaseService {
     validateAIAgentRepoOverride({ approvalPolicy });
 
     const currentConfig = await this.getGlobalConfig();
-    const nextApprovalPolicy = this.normalizeApprovalPolicy({
-      ...currentConfig.approvalPolicy,
-      ...approvalPolicy,
-      rules: approvalPolicy.rules ?? currentConfig.approvalPolicy?.rules,
-    });
+    const nextApprovalPolicy = this.normalizeApprovalPolicy(approvalPolicy);
     const nextConfig: AIAgentConfig = {
       ...currentConfig,
     };

--- a/src/server/services/types/agentSessionConfig.ts
+++ b/src/server/services/types/agentSessionConfig.ts
@@ -27,13 +27,45 @@ export interface AgentSessionToolRule {
 export interface AgentSessionControlPlaneConfigValue {
   systemPrompt?: string;
   appendSystemPrompt?: string;
+  maxIterations?: number;
+  workspaceToolDiscoveryTimeoutMs?: number;
+  workspaceToolExecutionTimeoutMs?: number;
   toolRules?: AgentSessionToolRule[];
 }
 
 export interface EffectiveAgentSessionControlPlaneConfig {
   systemPrompt: string;
   appendSystemPrompt?: string;
+  maxIterations: number;
+  workspaceToolDiscoveryTimeoutMs: number;
+  workspaceToolExecutionTimeoutMs: number;
   toolRules: AgentSessionToolRule[];
+}
+
+export interface AgentSessionReadinessSettingsValue {
+  timeoutMs?: number;
+  pollMs?: number;
+}
+
+export interface AgentSessionResourceRequirementsValue {
+  requests?: Record<string, string>;
+  limits?: Record<string, string>;
+}
+
+export interface AgentSessionRuntimeSettingsValue {
+  workspaceImage?: string;
+  workspaceEditorImage?: string;
+  workspaceGatewayImage?: string;
+  scheduling?: {
+    nodeSelector?: Record<string, string>;
+    keepAttachedServicesOnSessionNode?: boolean;
+  };
+  readiness?: AgentSessionReadinessSettingsValue;
+  resources?: {
+    workspace?: AgentSessionResourceRequirementsValue;
+    editor?: AgentSessionResourceRequirementsValue;
+    workspaceGateway?: AgentSessionResourceRequirementsValue;
+  };
 }
 
 export interface AgentSessionToolInventoryEntry {

--- a/src/server/services/types/globalConfig.ts
+++ b/src/server/services/types/globalConfig.ts
@@ -55,11 +55,15 @@ export type AppSetup = {
 export type AgentSessionControlPlaneConfig = {
   systemPrompt?: string;
   appendSystemPrompt?: string;
+  maxIterations?: number;
+  workspaceToolDiscoveryTimeoutMs?: number;
+  workspaceToolExecutionTimeoutMs?: number;
   toolRules?: import('./agentSessionConfig').AgentSessionToolRule[];
 };
 
 export type AgentSessionSchedulingConfig = {
   nodeSelector?: Record<string, string> | null;
+  keepAttachedServicesOnSessionNode?: boolean | null;
 };
 
 export type AgentSessionReadinessConfig = {

--- a/src/shared/openApiSpec.ts
+++ b/src/shared/openApiSpec.ts
@@ -1517,9 +1517,98 @@ export const openApiSpecificationForV2Api: OAS3Options = {
           properties: {
             systemPrompt: { type: 'string', maxLength: 50000 },
             appendSystemPrompt: { type: 'string', maxLength: 50000 },
+            maxIterations: { type: 'integer', minimum: 1 },
+            workspaceToolDiscoveryTimeoutMs: { type: 'integer', minimum: 1 },
+            workspaceToolExecutionTimeoutMs: { type: 'integer', minimum: 1 },
             toolRules: {
               type: 'array',
               items: { $ref: '#/components/schemas/AgentSessionToolRule' },
+            },
+          },
+          additionalProperties: false,
+        },
+
+        EffectiveAgentSessionControlPlaneConfig: {
+          type: 'object',
+          properties: {
+            systemPrompt: { type: 'string', minLength: 1, maxLength: 50000 },
+            appendSystemPrompt: { type: 'string', maxLength: 50000 },
+            maxIterations: { type: 'integer', minimum: 1 },
+            workspaceToolDiscoveryTimeoutMs: { type: 'integer', minimum: 1 },
+            workspaceToolExecutionTimeoutMs: { type: 'integer', minimum: 1 },
+            toolRules: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/AgentSessionToolRule' },
+            },
+          },
+          required: [
+            'systemPrompt',
+            'maxIterations',
+            'workspaceToolDiscoveryTimeoutMs',
+            'workspaceToolExecutionTimeoutMs',
+            'toolRules',
+          ],
+          additionalProperties: false,
+        },
+
+        AgentSessionStringRecord: {
+          type: 'object',
+          propertyNames: {
+            minLength: 1,
+          },
+          additionalProperties: {
+            type: 'string',
+            minLength: 1,
+          },
+        },
+
+        AgentSessionResourceRequirements: {
+          type: 'object',
+          properties: {
+            requests: { $ref: '#/components/schemas/AgentSessionStringRecord' },
+            limits: { $ref: '#/components/schemas/AgentSessionStringRecord' },
+          },
+          additionalProperties: false,
+        },
+
+        AgentSessionRuntimeSettings: {
+          type: 'object',
+          properties: {
+            workspaceImage: { type: 'string', minLength: 1, maxLength: 2048 },
+            workspaceEditorImage: { type: 'string', minLength: 1, maxLength: 2048 },
+            workspaceGatewayImage: { type: 'string', minLength: 1, maxLength: 2048 },
+            scheduling: {
+              type: 'object',
+              properties: {
+                nodeSelector: {
+                  $ref: '#/components/schemas/AgentSessionStringRecord',
+                },
+                keepAttachedServicesOnSessionNode: { type: 'boolean' },
+              },
+              additionalProperties: false,
+            },
+            readiness: {
+              type: 'object',
+              properties: {
+                timeoutMs: { type: 'integer', minimum: 0 },
+                pollMs: { type: 'integer', minimum: 0 },
+              },
+              additionalProperties: false,
+            },
+            resources: {
+              type: 'object',
+              properties: {
+                workspace: {
+                  $ref: '#/components/schemas/AgentSessionResourceRequirements',
+                },
+                editor: {
+                  $ref: '#/components/schemas/AgentSessionResourceRequirements',
+                },
+                workspaceGateway: {
+                  $ref: '#/components/schemas/AgentSessionResourceRequirements',
+                },
+              },
+              additionalProperties: false,
             },
           },
           additionalProperties: false,
@@ -1575,6 +1664,32 @@ export const openApiSpecificationForV2Api: OAS3Options = {
               type: 'object',
               properties: {
                 data: { $ref: '#/components/schemas/AgentSessionControlPlaneConfig' },
+              },
+            },
+          ],
+        },
+
+        GetEffectiveGlobalAgentSessionConfigSuccessResponse: {
+          allOf: [
+            { $ref: '#/components/schemas/SuccessApiResponse' },
+            {
+              type: 'object',
+              properties: {
+                data: {
+                  $ref: '#/components/schemas/EffectiveAgentSessionControlPlaneConfig',
+                },
+              },
+            },
+          ],
+        },
+
+        GetGlobalAgentSessionRuntimeConfigSuccessResponse: {
+          allOf: [
+            { $ref: '#/components/schemas/SuccessApiResponse' },
+            {
+              type: 'object',
+              properties: {
+                data: { $ref: '#/components/schemas/AgentSessionRuntimeSettings' },
               },
             },
           ],


### PR DESCRIPTION
- Move AI SDK agent-session runtime controls into admin-managed config
- Add support for maxIterations, workspace tool discovery/execution timeouts, and runtime workspace settings
- Expose runtime and effective config through the core API and OpenAPI
- Persist the session same-node attachment policy so later service attachments stay consistent
- Apply the discovery timeout to MCP tool listing and honor execution timeout on sandbox tools
- Add validation, defaults, migration updates, and focused unit coverage