### PR TITLE
fix: refresh external secrets before secret use

### DIFF
--- a/src/server/lib/agentSession/__tests__/forwardedEnv.test.ts
+++ b/src/server/lib/agentSession/__tests__/forwardedEnv.test.ts
@@ -84,6 +84,7 @@ describe('forwardedEnv', () => {
       processEnvSecrets: jest.fn().mockResolvedValue({
         secretRefs: [],
         expectedKeysPerSecret: {},
+        syncTokensPerSecret: {},
         warnings: [],
       }),
       waitForSecretSync: jest.fn().mockResolvedValue(undefined),
@@ -195,6 +196,9 @@ describe('forwardedEnv', () => {
       expectedKeysPerSecret: {
         'agent-env-session-123-aws-secrets': ['PRIVATE_REGISTRY_TOKEN'],
       },
+      syncTokensPerSecret: {
+        'agent-env-session-123-aws-secrets': 'sync-123',
+      },
       warnings: [],
     });
     const waitForSecretSync = jest.fn().mockResolvedValue(undefined);
@@ -241,7 +245,8 @@ describe('forwardedEnv', () => {
     expect(waitForSecretSync).toHaveBeenCalledWith(
       { 'agent-env-session-123-aws-secrets': ['PRIVATE_REGISTRY_TOKEN'] },
       'test-ns',
-      30000
+      30000,
+      { 'agent-env-session-123-aws-secrets': 'sync-123' }
     );
     expect(result.secretProviders).toEqual(['aws']);
   });

--- a/src/server/lib/agentSession/forwardedEnv.ts
+++ b/src/server/lib/agentSession/forwardedEnv.ts
@@ -157,7 +157,12 @@ export async function resolveForwardedAgentEnv(
       .map((provider) => provider.secretSyncTimeout)
       .filter((timeout): timeout is number => timeout !== undefined);
     const timeout = providerTimeouts.length > 0 ? Math.max(...providerTimeouts) * 1000 : 60000;
-    await secretProcessor.waitForSecretSync(secretResult.expectedKeysPerSecret, namespace, timeout);
+    await secretProcessor.waitForSecretSync(
+      secretResult.expectedKeysPerSecret,
+      namespace,
+      timeout,
+      secretResult.syncTokensPerSecret
+    );
   }
 
   return {

--- a/src/server/lib/kubernetes/__tests__/externalSecret.test.ts
+++ b/src/server/lib/kubernetes/__tests__/externalSecret.test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { generateExternalSecretManifest, generateSecretName, groupSecretRefsByProvider } from '../externalSecret';
+import {
+  EXTERNAL_SECRET_FORCE_SYNC_ANNOTATION,
+  generateExternalSecretManifest,
+  generateSecretName,
+  groupSecretRefsByProvider,
+  TARGET_SECRET_SYNC_TOKEN_ANNOTATION,
+} from '../externalSecret';
 import { SecretRefWithEnvKey } from 'server/lib/secretRefs';
 
 describe('externalSecret', () => {
@@ -90,6 +96,7 @@ describe('externalSecret', () => {
       expect(manifest.spec.secretStoreRef.name).toBe('aws-secretsmanager');
       expect(manifest.spec.secretStoreRef.kind).toBe('ClusterSecretStore');
       expect(manifest.spec.target.name).toBe('api-server-aws-secrets');
+      expect(manifest.spec.target.deletionPolicy).toBe('Merge');
       expect(manifest.spec.data).toHaveLength(2);
     });
 
@@ -166,6 +173,27 @@ describe('externalSecret', () => {
 
       expect(manifest.metadata.labels['app.kubernetes.io/managed-by']).toBe('lifecycle');
       expect(manifest.metadata.labels['lfc/uuid']).toBe('abc123');
+    });
+
+    it('adds sync metadata when a force sync token is provided', () => {
+      const refs: SecretRefWithEnvKey[] = [{ envKey: 'SECRET', provider: 'aws', path: 'path', key: 'key' }];
+
+      const manifest = generateExternalSecretManifest({
+        name: 'api-server',
+        namespace: 'lfc-abc123',
+        provider: 'aws',
+        secretRefs: refs,
+        providerConfig,
+        forceSyncToken: 'sync-123',
+      });
+
+      expect(manifest.metadata.annotations).toEqual({
+        [EXTERNAL_SECRET_FORCE_SYNC_ANNOTATION]: 'sync-123',
+      });
+      expect(manifest.spec.target.template?.metadata.annotations).toEqual({
+        [TARGET_SECRET_SYNC_TOKEN_ANNOTATION]: 'sync-123',
+      });
+      expect(manifest.spec.target.template?.metadata.labels).toEqual(manifest.metadata.labels);
     });
   });
 });

--- a/src/server/lib/kubernetes/externalSecret.ts
+++ b/src/server/lib/kubernetes/externalSecret.ts
@@ -23,7 +23,7 @@ import { SecretProviderConfig } from 'server/services/types/globalConfig';
 import { buildLifecycleLabels } from 'server/lib/kubernetes/labels';
 
 export const EXTERNAL_SECRET_FORCE_SYNC_ANNOTATION = 'force-sync';
-export const TARGET_SECRET_SYNC_TOKEN_ANNOTATION = 'lifecycle.dev/secret-sync-token';
+export const TARGET_SECRET_SYNC_TOKEN_ANNOTATION = 'lfc/secret-sync-token';
 
 export interface ExternalSecretManifest {
   apiVersion: string;

--- a/src/server/lib/kubernetes/externalSecret.ts
+++ b/src/server/lib/kubernetes/externalSecret.ts
@@ -22,6 +22,9 @@ import { SecretRefWithEnvKey } from 'server/lib/secretRefs';
 import { SecretProviderConfig } from 'server/services/types/globalConfig';
 import { buildLifecycleLabels } from 'server/lib/kubernetes/labels';
 
+export const EXTERNAL_SECRET_FORCE_SYNC_ANNOTATION = 'force-sync';
+export const TARGET_SECRET_SYNC_TOKEN_ANNOTATION = 'lifecycle.dev/secret-sync-token';
+
 export interface ExternalSecretManifest {
   apiVersion: string;
   kind: string;
@@ -29,6 +32,7 @@ export interface ExternalSecretManifest {
     name: string;
     namespace: string;
     labels: Record<string, string>;
+    annotations?: Record<string, string>;
   };
   spec: {
     refreshInterval: string;
@@ -38,6 +42,13 @@ export interface ExternalSecretManifest {
     };
     target: {
       name: string;
+      deletionPolicy: 'Merge';
+      template?: {
+        metadata: {
+          labels: Record<string, string>;
+          annotations: Record<string, string>;
+        };
+      };
     };
     data: Array<{
       secretKey: string;
@@ -56,6 +67,7 @@ export interface GenerateExternalSecretOptions {
   secretRefs: SecretRefWithEnvKey[];
   providerConfig: SecretProviderConfig;
   buildUuid?: string;
+  forceSyncToken?: string;
 }
 
 const MAX_NAME_LENGTH = 63;
@@ -87,7 +99,7 @@ export function groupSecretRefsByProvider(refs: SecretRefWithEnvKey[]): Record<s
 }
 
 export function generateExternalSecretManifest(options: GenerateExternalSecretOptions): ExternalSecretManifest {
-  const { name, namespace, provider, secretRefs, providerConfig, buildUuid } = options;
+  const { name, namespace, provider, secretRefs, providerConfig, buildUuid, forceSyncToken } = options;
 
   const secretName = generateSecretName(name, provider);
 
@@ -115,6 +127,22 @@ export function generateExternalSecretManifest(options: GenerateExternalSecretOp
     labels['lfc/uuid'] = buildUuid;
   }
 
+  const annotations = forceSyncToken
+    ? {
+        [EXTERNAL_SECRET_FORCE_SYNC_ANNOTATION]: forceSyncToken,
+      }
+    : undefined;
+  const targetTemplate = forceSyncToken
+    ? {
+        metadata: {
+          labels,
+          annotations: {
+            [TARGET_SECRET_SYNC_TOKEN_ANNOTATION]: forceSyncToken,
+          },
+        },
+      }
+    : undefined;
+
   return {
     apiVersion: 'external-secrets.io/v1',
     kind: 'ExternalSecret',
@@ -122,6 +150,7 @@ export function generateExternalSecretManifest(options: GenerateExternalSecretOp
       name: secretName,
       namespace,
       labels,
+      ...(annotations ? { annotations } : {}),
     },
     spec: {
       refreshInterval: providerConfig.refreshInterval,
@@ -131,6 +160,8 @@ export function generateExternalSecretManifest(options: GenerateExternalSecretOp
       },
       target: {
         name: secretName,
+        deletionPolicy: 'Merge',
+        ...(targetTemplate ? { template: targetTemplate } : {}),
       },
       data,
     },

--- a/src/server/services/__tests__/secretProcessor.test.ts
+++ b/src/server/services/__tests__/secretProcessor.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { SecretProcessor } from '../secretProcessor';
+import { TARGET_SECRET_SYNC_TOKEN_ANNOTATION } from 'server/lib/kubernetes/externalSecret';
 import { SecretProvidersConfig } from 'server/services/types/globalConfig';
 
 jest.mock('server/lib/kubernetes/externalSecret', () => ({
@@ -23,6 +24,8 @@ jest.mock('server/lib/kubernetes/externalSecret', () => ({
     .generateExternalSecretManifest,
   generateSecretName: jest.requireActual('server/lib/kubernetes/externalSecret').generateSecretName,
   groupSecretRefsByProvider: jest.requireActual('server/lib/kubernetes/externalSecret').groupSecretRefsByProvider,
+  TARGET_SECRET_SYNC_TOKEN_ANNOTATION: jest.requireActual('server/lib/kubernetes/externalSecret')
+    .TARGET_SECRET_SYNC_TOKEN_ANNOTATION,
 }));
 
 jest.mock('server/lib/logger', () => ({
@@ -133,6 +136,44 @@ describe('SecretProcessor', () => {
 
       await expect(
         processor.waitForSecretSync({ 'sample-service-aws-secrets': ['EXISTING_TOKEN', 'NEW_TOKEN'] }, 'test-ns', 5000)
+      ).resolves.toBeUndefined();
+
+      expect(mockReadNamespacedSecret).toHaveBeenCalledTimes(2);
+    });
+
+    it('waits until the secret has the expected sync token', async () => {
+      const mockReadNamespacedSecret = jest
+        .fn()
+        .mockResolvedValueOnce({
+          body: {
+            data: { API_TOKEN: 'b2xk' },
+            metadata: {
+              annotations: {
+                [TARGET_SECRET_SYNC_TOKEN_ANNOTATION]: 'old-token',
+              },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          body: {
+            data: { API_TOKEN: 'bmV3' },
+            metadata: {
+              annotations: {
+                [TARGET_SECRET_SYNC_TOKEN_ANNOTATION]: 'new-token',
+              },
+            },
+          },
+        });
+
+      jest.spyOn(processor as any, 'getK8sClient').mockReturnValue({
+        readNamespacedSecret: mockReadNamespacedSecret,
+      });
+      jest.spyOn(processor as any, 'sleep').mockResolvedValue(undefined);
+
+      await expect(
+        processor.waitForSecretSync({ 'my-secret': ['API_TOKEN'] }, 'test-ns', 5000, {
+          'my-secret': 'new-token',
+        })
       ).resolves.toBeUndefined();
 
       expect(mockReadNamespacedSecret).toHaveBeenCalledTimes(2);
@@ -286,6 +327,7 @@ describe('SecretProcessor', () => {
         serviceName: 'api-server',
         namespace: 'lfc-abc123',
         buildUuid: 'abc123',
+        syncToken: 'sync-123',
       });
 
       expect(applyExternalSecret).toHaveBeenCalledTimes(1);
@@ -293,6 +335,21 @@ describe('SecretProcessor', () => {
         expect.objectContaining({
           metadata: expect.objectContaining({
             name: 'api-server-aws-secrets',
+            annotations: {
+              'force-sync': 'sync-123',
+            },
+          }),
+          spec: expect.objectContaining({
+            target: expect.objectContaining({
+              deletionPolicy: 'Merge',
+              template: {
+                metadata: expect.objectContaining({
+                  annotations: {
+                    [TARGET_SECRET_SYNC_TOKEN_ANNOTATION]: 'sync-123',
+                  },
+                }),
+              },
+            }),
           }),
         }),
         'lfc-abc123'
@@ -373,6 +430,10 @@ describe('SecretProcessor', () => {
       expect(result.expectedKeysPerSecret).toEqual({
         'api-server-aws-secrets': ['AWS_SECRET'],
         'api-server-gcp-secrets': ['GCP_SECRET'],
+      });
+      expect(result.syncTokensPerSecret).toEqual({
+        'api-server-aws-secrets': expect.any(String),
+        'api-server-gcp-secrets': expect.any(String),
       });
     });
   });

--- a/src/server/services/deploy.ts
+++ b/src/server/services/deploy.ts
@@ -1170,7 +1170,8 @@ export default class DeployService extends BaseService {
                   await secretProcessor.waitForSecretSync(
                     secretResult.expectedKeysPerSecret,
                     deploy.build.namespace,
-                    timeout
+                    timeout,
+                    secretResult.syncTokensPerSecret
                   );
                   buildSecretNames = secretNames;
                   getLogger().info(`Build: secrets synced count=${buildSecretNames.length}`);

--- a/src/server/services/secretProcessor.ts
+++ b/src/server/services/secretProcessor.ts
@@ -21,9 +21,11 @@ import {
   generateExternalSecretManifest,
   groupSecretRefsByProvider,
   generateSecretName,
+  TARGET_SECRET_SYNC_TOKEN_ANNOTATION,
 } from 'server/lib/kubernetes/externalSecret';
 import { SecretProvidersConfig } from 'server/services/types/globalConfig';
 import { CoreV1Api, KubeConfig } from '@kubernetes/client-node';
+import { v4 as uuid } from 'uuid';
 
 const DEFAULT_SECRET_SYNC_TIMEOUT = 60000;
 
@@ -32,11 +34,13 @@ export interface ProcessEnvSecretsOptions {
   serviceName: string;
   namespace: string;
   buildUuid?: string;
+  syncToken?: string;
 }
 
 export interface ProcessEnvSecretsResult {
   secretRefs: SecretRefWithEnvKey[];
   expectedKeysPerSecret: Record<string, string[]>;
+  syncTokensPerSecret: Record<string, string>;
   warnings: string[];
 }
 
@@ -61,7 +65,8 @@ export class SecretProcessor {
   async waitForSecretSync(
     expectedKeysPerSecret: Record<string, string[]>,
     namespace: string,
-    timeoutMs?: number
+    timeoutMs?: number,
+    expectedSyncTokensPerSecret: Record<string, string> = {}
   ): Promise<void> {
     const timeout = timeoutMs ?? DEFAULT_SECRET_SYNC_TIMEOUT;
     const pollInterval = 1000;
@@ -72,24 +77,36 @@ export class SecretProcessor {
     for (const [secretName, expectedKeys] of Object.entries(expectedKeysPerSecret)) {
       let synced = false;
       let missingKeys = expectedKeys;
+      let syncedToken = false;
 
       while (!synced) {
         if (Date.now() - startTime > timeout) {
+          const tokenMessage =
+            expectedSyncTokensPerSecret[secretName] && !syncedToken ? ' sync token not observed' : '';
           throw new Error(
-            `Secret sync timeout: ${secretName} missing keys=[${missingKeys.join(', ')}] after ${timeout}ms`
+            `Secret sync timeout: ${secretName} missing keys=[${missingKeys.join(
+              ', '
+            )}]${tokenMessage} after ${timeout}ms`
           );
         }
 
         try {
           const response = await k8sClient.readNamespacedSecret(secretName, namespace);
           const data = response.body.data || {};
+          const annotations = response.body.metadata?.annotations || {};
+          const expectedSyncToken = expectedSyncTokensPerSecret[secretName];
           missingKeys = expectedKeys.filter((key) => !Object.prototype.hasOwnProperty.call(data, key));
+          syncedToken = !expectedSyncToken || annotations[TARGET_SECRET_SYNC_TOKEN_ANNOTATION] === expectedSyncToken;
 
-          if (missingKeys.length === 0) {
+          if (missingKeys.length === 0 && syncedToken) {
             getLogger().info(`Secret: synced name=${secretName} namespace=${namespace}`);
             synced = true;
           } else {
-            getLogger().debug(`Secret: waiting for keys name=${secretName} missing=[${missingKeys.join(', ')}]`);
+            getLogger().debug(
+              `Secret: waiting for keys name=${secretName} missing=[${missingKeys.join(
+                ', '
+              )}] syncedToken=${syncedToken}`
+            );
             await this.sleep(pollInterval);
           }
         } catch (error: any) {
@@ -110,6 +127,7 @@ export class SecretProcessor {
 
   async processEnvSecrets(options: ProcessEnvSecretsOptions): Promise<ProcessEnvSecretsResult> {
     const { env, serviceName, namespace, buildUuid } = options;
+    const syncToken = options.syncToken ?? uuid();
     const warnings: string[] = [];
     const validRefs: SecretRefWithEnvKey[] = [];
 
@@ -131,11 +149,12 @@ export class SecretProcessor {
     }
 
     if (validRefs.length === 0) {
-      return { secretRefs: [], expectedKeysPerSecret: {}, warnings };
+      return { secretRefs: [], expectedKeysPerSecret: {}, syncTokensPerSecret: {}, warnings };
     }
 
     const grouped = groupSecretRefsByProvider(validRefs);
     const expectedKeysPerSecret: Record<string, string[]> = {};
+    const syncTokensPerSecret: Record<string, string> = {};
 
     for (const [provider, refs] of Object.entries(grouped)) {
       const providerConfig = this.secretProviders![provider];
@@ -148,11 +167,13 @@ export class SecretProcessor {
         secretRefs: refs,
         providerConfig,
         buildUuid,
+        forceSyncToken: syncToken,
       });
 
       try {
         await applyExternalSecret(manifest, namespace);
         expectedKeysPerSecret[secretName] = [...new Set(refs.map((ref) => ref.envKey))];
+        syncTokensPerSecret[secretName] = syncToken;
       } catch (error) {
         const errorMsg = (error as any)?.message || (error as any)?.stderr || String(error);
         const warning = `Failed to apply ExternalSecret for ${serviceName}: ${errorMsg}`;
@@ -160,6 +181,6 @@ export class SecretProcessor {
       }
     }
 
-    return { secretRefs: validRefs, expectedKeysPerSecret, warnings };
+    return { secretRefs: validRefs, expectedKeysPerSecret, syncTokensPerSecret, warnings };
   }
 }


### PR DESCRIPTION
## What

This fixes native secret reference handling so each build or redeploy waits on the latest External Secrets Operator reconciliation before using the synced Kubernetes Secret.

Changes:

- Adds a per-run sync token to generated `ExternalSecret` resources using the documented `force-sync` annotation.
- Mirrors that sync token onto the target Kubernetes Secret through the ExternalSecret target template.
- Waits for both the expected Secret keys and the matching sync token before build or forwarded agent environment secret usage continues.
- Sets `target.deletionPolicy: Merge` so provider-side deletions remove stale keys from the target Secret instead of retaining old values.
- Covers deployment secrets and forwarded agent environment secrets with focused tests.

## Why

Previously, reapplying the same `ExternalSecret` manifest could leave a build or redeploy using stale Secret data until the configured refresh interval elapsed. Waiting only for key existence was also not enough because an old target Secret could already contain the requested key.

With this change, each processing run changes the ExternalSecret metadata, the operator reconciles immediately, and Lifecycle waits until the target Secret reflects that same run.

## Validation

- `pnpm run lint`
- `pnpm exec tsc --project tsconfig.server.json --noEmit --pretty false`
- `pnpm exec jest --runTestsByPath src/server/lib/kubernetes/__tests__/externalSecret.test.ts src/server/services/__tests__/secretProcessor.test.ts src/server/lib/agentSession/__tests__/forwardedEnv.test.ts --runInBand`
- `pnpm run test`

Note: `pnpm run ts-check` currently fails on existing repo-wide TypeScript errors in generated Next.js types, helper scripts, and unrelated API/service files. The changed server project passes `tsconfig.server.json`.

## References

- External Secrets Operator documents manual refresh by updating an ExternalSecret annotation, for example `force-sync`.
- External Secrets Operator documents `deletionPolicy: Merge` as removing deleted provider keys from the target Secret while leaving the Secret resource in place.
