### PR TITLE
feat: reconcile deleted yaml services

### DIFF
--- a/src/server/db/migrations/001_seed.ts
+++ b/src/server/db/migrations/001_seed.ts
@@ -342,7 +342,10 @@ export async function up(knex: Knex): Promise<any> {
       helm json DEFAULT '{}'::json,
       "deploymentDependsOn" text[] DEFAULT ARRAY[]::text[],
       builder jsonb DEFAULT '{}'::jsonb,
-      "ecr" varchar(255) default NULL::character varying
+      "ecr" varchar(255) default NULL::character varying,
+      source varchar(255) DEFAULT 'db'::character varying,
+      "reconcileEligible" boolean DEFAULT false,
+      "resolvedFromRepositoryId" integer
     );
     ALTER TABLE deployables OWNER TO lifecycle;
   `);
@@ -452,7 +455,7 @@ export async function up(knex: Knex): Promise<any> {
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('auroraRestoreSettings', '{"vpcId":"","accountId":"","region":"us-west-2","securityGroupIds":[],"subnetGroupName":"","engine":"aurora-mysql","engineVersion":"8.0.mysql_aurora.3.06.0","tagMatch":{"key":"restore-for"},"instanceSize":"db.t3.medium","restoreSize":"db.t3.small"}', now(), now(), null, 'Default aurora database settings to use for restore');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('rdsRestoreSettings', '{"vpcId":"","accountId":"","region":"us-west-2","securityGroupIds":[],"subnetGroupName":"","engine":"mysql","engineVersion":"8.0.33","tagMatch":{"key":"restore-for"},"instanceSize":"db.t3.small","restoreSize":"db.t3.small"}', now(), now(), null, 'Default RDS database settings to use for restore');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('minio', '{"version":"3.7.2","args":"--force --timeout 60m0s --wait","action":"install","chart":{"name":"minio","repoUrl":"https://charts.bitnami.com/bitnami","version":"15.0.7","values":[],"valueFiles":[]},"label":"labels","tolerations":"tolerations","affinity":"affinity","nodeSelector":"nodeSelector"}', now(), now(), null, 'Default minio s3 compatible bucket');
-    INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('features', '{"webhooks":true}', now(), now(), null, 'Configuration for feature flags controlled from database');
+    INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('features', '{"webhooks":true,"reconcileDeletedServices":false}', now(), now(), null, 'Configuration for feature flags controlled from database');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('serviceAccount', '{"name": "default","role":"replace_me"}', now(), now(), null, 'Default IAM role name to be used to annotate service account');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('app_setup', '{"state":"","created":false,"installed":false,"restarted":false,"org":"","url":"","name":""}', now(), now(), null, 'Application setup state');
     INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description) VALUES ('labels', '{"deploy":["lifecycle-deploy!"],"disabled":["lifecycle-disabled!"],"statusComments":["lifecycle-status-comments!"],"defaultStatusComments":true,"defaultControlComments":true}', now(), now(), null, 'Configurable PR labels for deploy, disabled, and status comments');

--- a/src/server/db/migrations/025_add_deployable_reconciliation_metadata.ts
+++ b/src/server/db/migrations/025_add_deployable_reconciliation_metadata.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2025 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+
+async function addColumnIfMissing(
+  knex: Knex,
+  tableName: string,
+  columnName: string,
+  addColumn: (table: Knex.AlterTableBuilder) => void
+): Promise<void> {
+  const exists = await knex.schema.hasColumn(tableName, columnName);
+
+  if (exists) {
+    return;
+  }
+
+  await knex.schema.alterTable(tableName, addColumn);
+}
+
+async function dropColumnIfExists(knex: Knex, tableName: string, columnName: string): Promise<void> {
+  const exists = await knex.schema.hasColumn(tableName, columnName);
+
+  if (!exists) {
+    return;
+  }
+
+  await knex.schema.alterTable(tableName, (table) => {
+    table.dropColumn(columnName);
+  });
+}
+
+export async function up(knex: Knex): Promise<void> {
+  await addColumnIfMissing(knex, 'deployables', 'source', (table) => {
+    table.string('source').defaultTo('db');
+  });
+  await addColumnIfMissing(knex, 'deployables', 'reconcileEligible', (table) => {
+    table.boolean('reconcileEligible').defaultTo(false);
+  });
+  await addColumnIfMissing(knex, 'deployables', 'resolvedFromRepositoryId', (table) => {
+    table.integer('resolvedFromRepositoryId').nullable();
+  });
+
+  await knex.raw(`
+    UPDATE deployables
+    SET
+      source = CASE
+        WHEN "serviceId" IS NULL THEN 'yaml'
+        ELSE COALESCE(source, 'db')
+      END,
+      "reconcileEligible" = CASE
+        WHEN "serviceId" IS NULL AND type <> 'configuration' THEN true
+        ELSE false
+      END,
+      "resolvedFromRepositoryId" = CASE
+        WHEN "repositoryId" ~ '^[0-9]+$' THEN "repositoryId"::integer
+        ELSE NULL
+      END
+    WHERE source IS NULL
+       OR "reconcileEligible" IS NULL
+       OR "resolvedFromRepositoryId" IS NULL;
+  `);
+
+  await knex.raw(`
+    INSERT INTO global_config (key, config, "createdAt", "updatedAt", "deletedAt", description)
+    VALUES (
+      'features',
+      '{"reconcileDeletedServices":false}',
+      now(),
+      now(),
+      null,
+      'Configuration for feature flags controlled from database'
+    )
+    ON CONFLICT (key) DO UPDATE
+    SET config = (
+          COALESCE(global_config.config, '{}'::json)::jsonb ||
+          CASE
+            WHEN jsonb_exists(global_config.config::jsonb, 'reconcileDeletedServices') THEN '{}'::jsonb
+            ELSE '{"reconcileDeletedServices":false}'::jsonb
+          END
+        )::json,
+        "updatedAt" = now(),
+        "deletedAt" = null;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    UPDATE global_config
+    SET config = (config::jsonb - 'reconcileDeletedServices')::json,
+        "updatedAt" = now()
+    WHERE key = 'features';
+  `);
+
+  await dropColumnIfExists(knex, 'deployables', 'resolvedFromRepositoryId');
+  await dropColumnIfExists(knex, 'deployables', 'reconcileEligible');
+  await dropColumnIfExists(knex, 'deployables', 'source');
+}

--- a/src/server/jobs/index.ts
+++ b/src/server/jobs/index.ts
@@ -107,6 +107,11 @@ export default function bootstrapJobs(services: IServices) {
     concurrency: 125,
   });
 
+  queueManager.registerWorker(QUEUE_NAMES.DEPLOY_CLEANUP, services.DeployCleanupService.processCleanupQueue, {
+    connection: redisClient.getConnection(),
+    concurrency: 5,
+  });
+
   queueManager.registerWorker(QUEUE_NAMES.LABEL, services.LabelService.processLabelQueue, {
     connection: redisClient.getConnection(),
     concurrency: 10,

--- a/src/server/lib/cli.ts
+++ b/src/server/lib/cli.ts
@@ -221,7 +221,7 @@ function contextForDeploy(deploy: Deploy, settings: string) {
  * Deletes a CLI deploy
  * @param deploy cli deploys to delete
  */
-async function deleteDeploy(deploy: Deploy) {
+export async function deleteDeploy(deploy: Deploy) {
   const serviceCmd = deploy.build.enableFullYaml ? deploy.deployable.command : deploy.service.command;
 
   const { settings, region } = await getSettingsFor(serviceCmd);

--- a/src/server/models/Deployable.ts
+++ b/src/server/models/Deployable.ts
@@ -17,6 +17,7 @@
 import Model from './_Model';
 import { Environment, Repository, Service, ServiceDisk } from '.';
 import { Builder, Helm } from './yaml/YamlService';
+import type { DeployableConfigSource } from 'server/services/deployable';
 
 export default class Deployable extends Service {
   static tableName = 'deployables';
@@ -37,6 +38,9 @@ export default class Deployable extends Service {
   deploymentDependsOn: string[];
   builder: Builder;
   envLens?: boolean;
+  source?: DeployableConfigSource;
+  reconcileEligible?: boolean;
+  resolvedFromRepositoryId?: number | null;
 
   static relationMappings = {
     environment: {

--- a/src/server/services/__tests__/build.test.ts
+++ b/src/server/services/__tests__/build.test.ts
@@ -513,6 +513,46 @@ describe('BuildService stale deploy reconciliation', () => {
     expect(mockDeleteServiceRows).toHaveBeenCalledWith({ buildId: 10, deployableIds: [1] });
     expect(build.$fetchGraph).toHaveBeenCalledWith('[deployables, deploys]');
   });
+
+  test('service redeploy YAML import skips stale reconciliation', async () => {
+    const upsertDeployables = jest.fn().mockResolvedValue({
+      canReconcile: true,
+      deployables: [],
+      reconcileEligibleDeployables: [{ name: 'api', source: 'yaml', reconcileEligible: true }],
+    });
+    const upsertWebhooksWithYaml = jest.fn().mockResolvedValue(undefined);
+    const reconcileDeletedDeployables = jest.fn();
+    const queueManager = {
+      registerQueue: jest.fn(() => ({
+        add: jest.fn(),
+        process: jest.fn(),
+        on: jest.fn(),
+      })),
+    };
+    buildService = new BuildService(
+      {
+        services: {
+          Deployable: { upsertDeployables },
+          Webhook: { upsertWebhooksWithYaml },
+        },
+      } as any,
+      {} as any,
+      {} as any,
+      queueManager as any
+    );
+    (buildService as any).reconcileDeletedDeployables = reconcileDeletedDeployables;
+
+    const build = createBuild({ pullRequest: { id: 20 } });
+    const environment = { id: 30 };
+
+    await (buildService as any).importYamlConfigFile(environment, build, targetRepoId, {
+      skipDeletedServiceReconciliation: true,
+    });
+
+    expect(upsertDeployables).toHaveBeenCalledWith(10, 'build-1', build.pullRequest, environment, build, targetRepoId);
+    expect(reconcileDeletedDeployables).not.toHaveBeenCalled();
+    expect(upsertWebhooksWithYaml).toHaveBeenCalledWith(build, build.pullRequest);
+  });
 });
 
 describe('BuildService queue fingerprinting', () => {
@@ -664,6 +704,72 @@ describe('BuildService queue fingerprinting', () => {
       }),
       expect.objectContaining({
         jobId: `build:1:${expectedFingerprint}`,
+      })
+    );
+  });
+
+  test('service redeploy queues scoped build without deleted-service reconciliation', async () => {
+    const patchAndFetch = jest.fn().mockResolvedValue(undefined);
+    const deploy = {
+      id: 33,
+      uuid: 'pdm-db-good-dev-0',
+      githubRepositoryId: 425935548,
+      deployable: {
+        name: 'pdm-db',
+        repositoryId: 425935548,
+      },
+      $query: jest.fn(() => ({ patchAndFetch })),
+    };
+    const build = createMockBuild({
+      id: 1449,
+      uuid: 'good-dev-0',
+      deploys: [deploy],
+    });
+    mockBuildQuery.withGraphFetched.mockResolvedValue(build);
+
+    await buildService.redeployServiceFromBuild('good-dev-0', 'pdm-db');
+
+    expect(mockResolveQueueAdd).toHaveBeenCalledWith(
+      'resolve-deploy',
+      expect.objectContaining({
+        buildId: 1449,
+        githubRepositoryId: 425935548,
+        skipDeletedServiceReconciliation: true,
+      }),
+      expect.any(Object)
+    );
+    expect(patchAndFetch).toHaveBeenCalledWith({
+      runUUID: expect.any(String),
+    });
+  });
+
+  test('resolve queue preserves deleted-service reconciliation skip flag for service redeploys', async () => {
+    const build = createMockBuild({
+      id: 1449,
+      uuid: 'good-dev-0',
+      pullRequest: {
+        latestCommit: 'abcdef123456',
+        deployOnUpdate: true,
+        $fetchGraph: jest.fn().mockResolvedValue(undefined),
+      },
+      $fetchGraph: jest.fn().mockResolvedValue(undefined),
+    });
+    mockBuildQuery.findOne.mockResolvedValue(build);
+    const enqueueBuildJob = jest.spyOn(buildService, 'enqueueBuildJob').mockResolvedValue(undefined as any);
+
+    await buildService.processResolveAndDeployBuildQueue({
+      data: {
+        buildId: 1449,
+        githubRepositoryId: 425935548,
+        skipDeletedServiceReconciliation: true,
+      },
+    });
+
+    expect(enqueueBuildJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buildId: 1449,
+        githubRepositoryId: 425935548,
+        skipDeletedServiceReconciliation: true,
       })
     );
   });

--- a/src/server/services/__tests__/build.test.ts
+++ b/src/server/services/__tests__/build.test.ts
@@ -19,7 +19,10 @@ const mockGenerateManifest = jest.fn();
 const mockApplyManifests = jest.fn();
 const mockWaitForPodReady = jest.fn();
 const mockGetAllConfigs = jest.fn();
+const mockIsFeatureEnabled = jest.fn();
 const mockQueueAdd = jest.fn();
+const mockCleanupDeploy = jest.fn();
+const mockDeleteServiceRows = jest.fn();
 
 jest.mock('server/lib/dependencies', () => ({
   defaultDb: {},
@@ -55,10 +58,12 @@ jest.mock('server/lib/logger', () => ({
 jest.mock('shared/config', () => ({
   TMP_PATH: '/tmp',
   QUEUE_NAMES: {
-    BUILD_QUEUE: 'build',
-    RESOLVE_DEPLOY_BUILD_QUEUE: 'resolve-deploy',
-    BUILD_CLEANUP_QUEUE: 'build-cleanup',
-    BUILD_REQUEST_QUEUE: 'build-request',
+    DELETE_QUEUE: 'delete_queue_test',
+    BUILD_QUEUE: 'build_queue_test',
+    RESOLVE_AND_DEPLOY: 'resolve_and_deploy_test',
+    BUILD_CLEANUP_QUEUE: 'build_cleanup_test',
+    BUILD_REQUEST_QUEUE: 'build_request_test',
+    DEPLOY_CLEANUP: 'deploy_cleanup_test',
     GLOBAL_CONFIG_CACHE_REFRESH: 'global-config-refresh',
     GITHUB_CLIENT_TOKEN_CACHE_REFRESH: 'github-client-token-refresh',
     INGRESS_MANIFEST_QUEUE: 'ingress-manifest',
@@ -88,6 +93,8 @@ jest.mock('server/lib/github', () => ({
   createGitDeployment: jest.fn(),
   updateGitDeploymentStatus: jest.fn(),
   getPullRequest: jest.fn(),
+  getSHAForBranch: jest.fn(),
+  getYamlFileContentFromBranch: jest.fn(),
 }));
 
 jest.mock('server/lib/helm', () => ({
@@ -104,23 +111,35 @@ jest.mock('server/lib/buildEnvVariables', () => ({
   })),
 }));
 
-jest.mock('server/services/deploy', () => ({
-  __esModule: true,
-  default: jest.fn().mockImplementation(() => ({})),
-}));
-
-jest.mock('server/services/webhook', () => ({
-  __esModule: true,
-  default: jest.fn().mockImplementation(() => ({})),
-}));
-
 jest.mock('server/services/globalConfig', () => ({
   __esModule: true,
   default: {
     getInstance: jest.fn(() => ({
       getAllConfigs: (...args: any[]) => mockGetAllConfigs(...args),
+      isFeatureEnabled: (...args: any[]) => mockIsFeatureEnabled(...args),
     })),
   },
+}));
+
+jest.mock('server/services/deployCleanup', () =>
+  jest.fn().mockImplementation(() => ({
+    cleanupDeploy: (...args: any[]) => mockCleanupDeploy(...args),
+    deleteServiceRows: (...args: any[]) => mockDeleteServiceRows(...args),
+  }))
+);
+
+jest.mock('server/services/deploy', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    patchAndUpdateActivityFeed: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('server/services/webhook', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    upsertWebhooksWithYaml: jest.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 jest.mock('server/lib/fastly', () =>
@@ -131,6 +150,19 @@ jest.mock('server/lib/fastly', () =>
 
 import BuildService from '../build';
 import { BuildKind, BuildStatus, DeployStatus, DeployTypes } from 'shared/constants';
+
+function createThenableQuery(result: any[] = []) {
+  const query: any = {
+    where: jest.fn(() => query),
+    whereIn: jest.fn(() => query),
+    whereNot: jest.fn(() => query),
+    whereNotNull: jest.fn(() => query),
+    delete: jest.fn().mockResolvedValue(result.length),
+    then: (resolve: (value: any[]) => void, reject: (reason: unknown) => void) =>
+      Promise.resolve(result).then(resolve, reject),
+  };
+  return query;
+}
 
 describe('BuildService failure boundaries', () => {
   let buildService: BuildService;
@@ -255,6 +287,231 @@ describe('BuildService status updates', () => {
       status: BuildStatus.DEPLOYED,
       statusMessage: '',
     });
+  });
+});
+
+describe('BuildService stale deploy reconciliation', () => {
+  let buildService: BuildService;
+  let deployableQuery: any;
+  let deployQuery: any;
+  const targetRepoId = 1001;
+  const otherRepoId = 2002;
+
+  const createService = (existingDeployables: any[] = [], staleDeploys: any[] = []) => {
+    deployableQuery = createThenableQuery(existingDeployables);
+    deployQuery = {
+      where: jest.fn(() => deployQuery),
+      whereIn: jest.fn(() => deployQuery),
+      withGraphFetched: jest.fn().mockResolvedValue(staleDeploys),
+    };
+
+    buildService = new BuildService(
+      {
+        models: {
+          Deployable: {
+            query: jest.fn().mockReturnValueOnce(deployableQuery),
+          },
+          Deploy: {
+            query: jest.fn().mockReturnValueOnce(deployQuery),
+          },
+        },
+      } as any,
+      {} as any,
+      {} as any,
+      {
+        registerQueue: jest.fn(() => ({
+          add: jest.fn(),
+          process: jest.fn(),
+          on: jest.fn(),
+        })),
+      } as any
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsFeatureEnabled.mockResolvedValue(true);
+    mockCleanupDeploy.mockResolvedValue(true);
+    mockDeleteServiceRows.mockResolvedValue(undefined);
+  });
+
+  const createBuild = (overrides: any = {}) =>
+    ({
+      id: 10,
+      uuid: 'build-1',
+      enableFullYaml: true,
+      $fetchGraph: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    } as any);
+
+  test('feature flag off leaves stale deployables untouched', async () => {
+    createService([{ id: 1, name: 'old-api' }]);
+    mockIsFeatureEnabled.mockResolvedValue(false);
+
+    await (buildService as any).reconcileDeletedDeployables({ id: 10, uuid: 'build-1', enableFullYaml: true } as any, {
+      canReconcile: true,
+      deployables: [],
+      reconcileEligibleDeployables: [{ name: 'api', source: 'yaml', reconcileEligible: true }],
+    });
+
+    expect((buildService as any).db.models.Deployable.query).not.toHaveBeenCalled();
+    expect(mockCleanupDeploy).not.toHaveBeenCalled();
+    expect(mockDeleteServiceRows).not.toHaveBeenCalled();
+  });
+
+  test('cleans stale YAML-owned deployables and deletes deploy/deployable rows', async () => {
+    const staleDeploy = { id: 77, uuid: 'old-api-build-1', deployableId: 1 };
+    createService(
+      [
+        { id: 1, name: 'old-api' },
+        { id: 2, name: 'api' },
+      ],
+      [staleDeploy]
+    );
+    const build = createBuild();
+
+    await (buildService as any).reconcileDeletedDeployables(build as any, {
+      canReconcile: true,
+      deployables: [],
+      reconcileEligibleDeployables: [{ name: 'api', source: 'yaml', reconcileEligible: true }],
+    });
+
+    expect(mockCleanupDeploy).toHaveBeenCalledWith(staleDeploy, { mode: 'service' });
+    expect(deployQuery.whereIn).toHaveBeenCalledWith('deployableId', [1]);
+    expect(mockDeleteServiceRows).toHaveBeenCalledWith({ buildId: 10, deployableIds: [1] });
+    expect(build.$fetchGraph).toHaveBeenCalledWith('[deployables, deploys]');
+  });
+
+  test('treats renamed YAML services as deleted old service plus created new service', async () => {
+    const staleDeploy = { id: 78, uuid: 'worker-old-build-1', deployableId: 3 };
+    createService(
+      [
+        { id: 2, name: 'api', resolvedFromRepositoryId: targetRepoId },
+        { id: 3, name: 'worker-old', resolvedFromRepositoryId: targetRepoId },
+      ],
+      [staleDeploy]
+    );
+    const build = createBuild();
+
+    await (buildService as any).reconcileDeletedDeployables(build, {
+      canReconcile: true,
+      deployables: [],
+      reconcileEligibleDeployables: [
+        { name: 'api', source: 'yaml', reconcileEligible: true, resolvedFromRepositoryId: targetRepoId },
+        { name: 'worker-new', source: 'yaml', reconcileEligible: true, resolvedFromRepositoryId: targetRepoId },
+      ],
+    });
+
+    expect(mockCleanupDeploy).toHaveBeenCalledTimes(1);
+    expect(mockCleanupDeploy).toHaveBeenCalledWith(staleDeploy, { mode: 'service' });
+    expect(mockDeleteServiceRows).toHaveBeenCalledWith({ buildId: 10, deployableIds: [3] });
+    expect(build.$fetchGraph).toHaveBeenCalledWith('[deployables, deploys]');
+  });
+
+  test('repo-filtered reconciliation removes only deployables from the triggering repository scope', async () => {
+    const staleDeploy = { id: 79, uuid: 'target-old-build-1', deployableId: 4 };
+    createService([{ id: 4, name: 'target-old', resolvedFromRepositoryId: targetRepoId }], [staleDeploy]);
+    const build = createBuild();
+
+    await (buildService as any).reconcileDeletedDeployables(
+      build,
+      {
+        canReconcile: true,
+        deployables: [],
+        reconcileEligibleDeployables: [
+          { name: 'target-new', source: 'yaml', reconcileEligible: true, resolvedFromRepositoryId: targetRepoId },
+          { name: 'other-service', source: 'yaml', reconcileEligible: true, resolvedFromRepositoryId: otherRepoId },
+        ],
+      },
+      targetRepoId
+    );
+
+    expect(deployableQuery.where).toHaveBeenCalledWith('resolvedFromRepositoryId', targetRepoId);
+    expect(deployableQuery.whereNotNull).toHaveBeenCalledWith('resolvedFromRepositoryId');
+    expect(mockCleanupDeploy).toHaveBeenCalledWith(staleDeploy, { mode: 'service' });
+    expect(mockDeleteServiceRows).toHaveBeenCalledWith({ buildId: 10, deployableIds: [4] });
+  });
+
+  test('full reconciliation can delete YAML-owned deployables with null repository ownership', async () => {
+    const staleDeploy = { id: 80, uuid: 'external-cache-build-1', deployableId: 5 };
+    createService([{ id: 5, name: 'external-cache', resolvedFromRepositoryId: null }], [staleDeploy]);
+    const build = createBuild();
+
+    await (buildService as any).reconcileDeletedDeployables(build, {
+      canReconcile: true,
+      deployables: [],
+      reconcileEligibleDeployables: [{ name: 'api', source: 'yaml', reconcileEligible: true }],
+    });
+
+    expect(mockCleanupDeploy).toHaveBeenCalledWith(staleDeploy, { mode: 'service' });
+    expect(mockDeleteServiceRows).toHaveBeenCalledWith({ buildId: 10, deployableIds: [5] });
+  });
+
+  test('repo-filtered reconciliation excludes ambiguous null repository ownership', async () => {
+    createService([], []);
+
+    await (buildService as any).reconcileDeletedDeployables(
+      { id: 10, uuid: 'build-1', enableFullYaml: true } as any,
+      {
+        canReconcile: true,
+        deployables: [],
+        reconcileEligibleDeployables: [],
+      },
+      123
+    );
+
+    expect(deployableQuery.where).toHaveBeenCalledWith('resolvedFromRepositoryId', 123);
+    expect(deployableQuery.whereNotNull).toHaveBeenCalledWith('resolvedFromRepositoryId');
+    expect(mockCleanupDeploy).not.toHaveBeenCalled();
+    expect(mockDeleteServiceRows).not.toHaveBeenCalled();
+  });
+
+  test('skips cleanup when YAML import did not resolve the authoritative config scope', async () => {
+    createService([{ id: 1, name: 'old-api' }], [{ id: 77, uuid: 'old-api-build-1', deployableId: 1 }]);
+
+    await (buildService as any).reconcileDeletedDeployables(createBuild(), {
+      canReconcile: false,
+      deployables: [],
+      reconcileEligibleDeployables: [],
+    });
+
+    expect((buildService as any).db.models.Deployable.query).not.toHaveBeenCalled();
+    expect(mockCleanupDeploy).not.toHaveBeenCalled();
+    expect(mockDeleteServiceRows).not.toHaveBeenCalled();
+  });
+
+  test('stale lookup is scoped to YAML-owned non-configuration deployables', async () => {
+    createService([], []);
+
+    await (buildService as any).reconcileDeletedDeployables(createBuild(), {
+      canReconcile: true,
+      deployables: [],
+      reconcileEligibleDeployables: [],
+    });
+
+    expect(deployableQuery.where).toHaveBeenCalledWith({
+      buildId: 10,
+      buildUUID: 'build-1',
+      reconcileEligible: true,
+      source: 'yaml',
+    });
+    expect(deployableQuery.whereNot).toHaveBeenCalledWith('type', DeployTypes.CONFIGURATION);
+  });
+
+  test('cleanup errors are logged but database rows are still deleted', async () => {
+    createService([{ id: 1, name: 'old-api' }], [{ id: 77, uuid: 'old-api-build-1', deployableId: 1 }]);
+    mockCleanupDeploy.mockRejectedValue(new Error('targeted cleanup failed'));
+    const build = createBuild();
+
+    await (buildService as any).reconcileDeletedDeployables(build as any, {
+      canReconcile: true,
+      deployables: [],
+      reconcileEligibleDeployables: [],
+    });
+
+    expect(mockCleanupDeploy).toHaveBeenCalledTimes(1);
+    expect(mockDeleteServiceRows).toHaveBeenCalledWith({ buildId: 10, deployableIds: [1] });
+    expect(build.$fetchGraph).toHaveBeenCalledWith('[deployables, deploys]');
   });
 });
 

--- a/src/server/services/__tests__/deployCleanup.test.ts
+++ b/src/server/services/__tests__/deployCleanup.test.ts
@@ -155,6 +155,24 @@ describe('DeployCleanupService', () => {
     expect(mockDeleteDeploy).not.toHaveBeenCalled();
   });
 
+  test('registers infra cleanup queue without automatic retries', () => {
+    const queueManager = createQueueManager();
+
+    new DeployCleanupService({} as any, {} as any, {} as any, queueManager as any);
+
+    expect(queueManager.registerQueue).toHaveBeenCalledWith(
+      'deploy_cleanup_test',
+      expect.objectContaining({
+        defaultJobOptions: expect.objectContaining({
+          attempts: 1,
+          removeOnComplete: 100,
+          removeOnFail: 100,
+        }),
+      })
+    );
+    expect(queueManager.registerQueue.mock.calls[0][1].defaultJobOptions).not.toHaveProperty('backoff');
+  });
+
   test('runs the existing codefresh destroy for stale codefresh deploys', async () => {
     const deploy = createDeploy({
       deployable: {
@@ -220,6 +238,38 @@ describe('DeployCleanupService', () => {
         status: DeployStatus.TORN_DOWN,
       })
     );
+  });
+
+  test('infra queue job fails when cleanup is incomplete and leaves deploy status unchanged', async () => {
+    mockShellPromise.mockImplementation((command: string) => {
+      if (command.includes('kubectl delete deployment')) {
+        return Promise.reject(new Error('deployment delete failed'));
+      }
+      return Promise.resolve('');
+    });
+    const deploy = createDeploy();
+    const query = {
+      findById: jest.fn(() => query),
+      withGraphFetched: jest.fn().mockResolvedValue(deploy),
+    };
+    const service = createService({
+      models: {
+        Deploy: {
+          query: jest.fn(() => query),
+        },
+      },
+    });
+
+    await expect(
+      service.processCleanupQueue({
+        data: {
+          deployId: 77,
+          mode: 'infra',
+        },
+      } as any)
+    ).rejects.toThrow('Deploy cleanup failed deployId=77 mode=infra');
+
+    expect(deploy.patch).not.toHaveBeenCalled();
   });
 
   test('infra partial failure leaves deploy status unchanged', async () => {

--- a/src/server/services/__tests__/deployCleanup.test.ts
+++ b/src/server/services/__tests__/deployCleanup.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Copyright 2026 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const mockShellPromise = jest.fn();
+const mockCodefreshDestroy = jest.fn();
+const mockDeleteDeploy = jest.fn();
+const mockMetricsIncrement = jest.fn().mockReturnThis();
+
+jest.mock('server/lib/dependencies', () => ({
+  defaultDb: {},
+  defaultRedis: {},
+  defaultRedlock: {},
+  defaultQueueManager: {},
+  redisClient: {
+    getConnection: jest.fn(),
+  },
+}));
+
+jest.mock('shared/config', () => ({
+  QUEUE_NAMES: {
+    DEPLOY_CLEANUP: 'deploy_cleanup_test',
+  },
+}));
+
+jest.mock('server/lib/shell', () => ({
+  shellPromise: (...args: any[]) => mockShellPromise(...args),
+}));
+
+jest.mock('server/lib/cli', () => ({
+  codefreshDestroy: (...args: any[]) => mockCodefreshDestroy(...args),
+  deleteDeploy: (...args: any[]) => mockDeleteDeploy(...args),
+}));
+
+jest.mock('server/lib/metrics', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    increment: mockMetricsIncrement,
+  })),
+  Metrics: jest.fn().mockImplementation(() => ({
+    increment: mockMetricsIncrement,
+  })),
+}));
+
+jest.mock('server/lib/logger', () => ({
+  getLogger: jest.fn(() => ({
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  })),
+  withLogContext: jest.fn((_ctx, fn) => fn()),
+  extractContextForQueue: jest.fn(() => ({})),
+}));
+
+import DeployCleanupService from '../deployCleanup';
+import { DeployStatus, DeployTypes } from 'shared/constants';
+
+describe('DeployCleanupService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockShellPromise.mockResolvedValue('');
+    mockCodefreshDestroy.mockResolvedValue('codefresh-build-id');
+    mockDeleteDeploy.mockResolvedValue('');
+  });
+
+  function createQueueManager(queueAdd = jest.fn()) {
+    return {
+      registerQueue: jest.fn(() => ({
+        add: queueAdd,
+      })),
+    };
+  }
+
+  function createService(db: any = {}, queueAdd = jest.fn()) {
+    return new DeployCleanupService(db, {} as any, {} as any, createQueueManager(queueAdd) as any);
+  }
+
+  function createDeploy(overrides: any = {}) {
+    const patch = jest.fn().mockResolvedValue(undefined);
+    return {
+      id: 77,
+      uuid: 'old-api-build-1',
+      deployableId: 9,
+      build: {
+        uuid: 'build-1',
+        namespace: 'env-build-1',
+      },
+      deployable: {
+        name: 'old-api',
+        type: DeployTypes.HELM,
+        serviceDisksYaml: JSON.stringify([{ name: 'data' }]),
+      },
+      service: null,
+      env: {
+        API_TOKEN: '{{aws:/service/api:token}}',
+      },
+      initEnv: {},
+      $fetchGraph: jest.fn().mockResolvedValue(undefined),
+      $query: jest.fn(() => ({ patch })),
+      patch,
+      ...overrides,
+    } as any;
+  }
+
+  test('uses deploy-targeted Kubernetes and Helm cleanup only', async () => {
+    const deploy = createDeploy();
+    const service = createService();
+
+    await service.cleanupDeploy(deploy, { mode: 'service' });
+
+    const commands = mockShellPromise.mock.calls.map(([command]) => command as string);
+    const joinedCommands = commands.join('\n');
+
+    expect(commands).toContain(
+      "kubectl delete deployment 'old-api-build-1' --namespace 'env-build-1' --ignore-not-found"
+    );
+    expect(commands).toContain(
+      "kubectl delete service 'old-api-build-1' 'internal-lb-old-api-build-1' --namespace 'env-build-1' --ignore-not-found"
+    );
+    expect(commands).toContain(
+      "kubectl delete ingress 'ingress-old-api-build-1' --namespace 'env-build-1' --ignore-not-found"
+    );
+    expect(commands).toContain(
+      "kubectl delete pvc 'old-api-build-1-data-claim' --namespace 'env-build-1' --ignore-not-found"
+    );
+    expect(commands).toContain("helm uninstall 'old-api-build-1' --namespace 'env-build-1'");
+    expect(joinedCommands).toContain('deploy_uuid=old-api-build-1');
+    expect(joinedCommands).toContain('deploy-id=77');
+    expect(joinedCommands).toContain('deployable-id=9');
+    expect(joinedCommands).not.toContain('service=old-api');
+    expect(joinedCommands).toContain(
+      "kubectl delete externalsecret 'old-api-aws-secrets' --namespace 'env-build-1' --ignore-not-found"
+    );
+    expect(joinedCommands).toContain(
+      "kubectl delete secret 'old-api-aws-secrets' --namespace 'env-build-1' --ignore-not-found"
+    );
+
+    expect(joinedCommands).not.toContain('delete namespace');
+    expect(joinedCommands).not.toContain('delete all,pvc');
+    expect(joinedCommands).not.toContain('lc_uuid=build-1');
+    expect(mockCodefreshDestroy).not.toHaveBeenCalled();
+    expect(mockDeleteDeploy).not.toHaveBeenCalled();
+  });
+
+  test('runs the existing codefresh destroy for stale codefresh deploys', async () => {
+    const deploy = createDeploy({
+      deployable: {
+        name: 'old-codefresh',
+        type: DeployTypes.CODEFRESH,
+        serviceDisksYaml: null,
+      },
+      env: {},
+    });
+    const service = createService();
+
+    await service.cleanupDeploy(deploy, { mode: 'service' });
+
+    expect(mockCodefreshDestroy).toHaveBeenCalledWith(deploy);
+    expect(mockDeleteDeploy).not.toHaveBeenCalled();
+  });
+
+  test('service mode continues after a targeted teardown failure', async () => {
+    mockShellPromise.mockImplementation((command: string) => {
+      if (command.includes('kubectl delete deployment')) {
+        return Promise.reject(new Error('deployment delete failed'));
+      }
+      return Promise.resolve('');
+    });
+    const deploy = createDeploy();
+    const service = createService();
+
+    await expect(service.cleanupDeploy(deploy, { mode: 'service' })).resolves.toBe(false);
+
+    const commands = mockShellPromise.mock.calls.map(([command]) => command as string);
+    expect(commands).toContain("helm uninstall 'old-api-build-1' --namespace 'env-build-1'");
+    expect(mockMetricsIncrement).toHaveBeenCalledWith(
+      'task',
+      expect.objectContaining({ result: 'error', resourceType: 'deployment' })
+    );
+    expect(deploy.patch).not.toHaveBeenCalled();
+  });
+
+  test('infra queue job marks deploy torn_down when cleanup succeeds', async () => {
+    const deploy = createDeploy();
+    const query = {
+      findById: jest.fn(() => query),
+      withGraphFetched: jest.fn().mockResolvedValue(deploy),
+    };
+    const service = createService({
+      models: {
+        Deploy: {
+          query: jest.fn(() => query),
+        },
+      },
+    });
+
+    await service.processCleanupQueue({
+      data: {
+        deployId: 77,
+        mode: 'infra',
+      },
+    } as any);
+
+    expect(query.findById).toHaveBeenCalledWith(77);
+    expect(deploy.patch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: DeployStatus.TORN_DOWN,
+      })
+    );
+  });
+
+  test('infra partial failure leaves deploy status unchanged', async () => {
+    mockShellPromise.mockImplementation((command: string) => {
+      if (command.includes('kubectl delete deployment')) {
+        return Promise.reject(new Error('deployment delete failed'));
+      }
+      return Promise.resolve('');
+    });
+    const deploy = createDeploy();
+    const service = createService();
+
+    await expect(service.cleanupDeploy(deploy, { mode: 'infra' })).resolves.toBe(false);
+
+    expect(deploy.patch).not.toHaveBeenCalled();
+  });
+
+  test('missing Kubernetes resource types are skipped without failing infra cleanup', async () => {
+    mockShellPromise.mockImplementation((command: string) => {
+      if (command.includes('kubectl delete mapping')) {
+        return Promise.reject(new Error('error: the server doesn\'t have a resource type "mapping"'));
+      }
+      return Promise.resolve('');
+    });
+    const deploy = createDeploy();
+    const service = createService();
+
+    await expect(service.cleanupDeploy(deploy, { mode: 'infra' })).resolves.toBe(true);
+
+    expect(mockMetricsIncrement).toHaveBeenCalledWith(
+      'task',
+      expect.objectContaining({ result: 'skipped_missing_resource_type', resourceType: 'mapping' })
+    );
+    expect(deploy.patch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: DeployStatus.TORN_DOWN,
+      })
+    );
+  });
+
+  test('enqueueCleanup queues infra cleanup jobs', async () => {
+    const queueAdd = jest.fn().mockResolvedValue(undefined);
+    const service = createService({}, queueAdd);
+
+    await service.enqueueCleanup({ deployId: 77, mode: 'infra' });
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      'cleanup',
+      expect.objectContaining({
+        deployId: 77,
+        mode: 'infra',
+      })
+    );
+  });
+
+  test('deleteServiceRows deletes matching deploys before deployables in one transaction', async () => {
+    const trx = { id: 'trx-1' };
+    const deployDelete = jest.fn().mockResolvedValue(2);
+    const deployableDelete = jest.fn().mockResolvedValue(2);
+    const deployQuery = {
+      where: jest.fn(() => deployQuery),
+      whereIn: jest.fn(() => deployQuery),
+      delete: deployDelete,
+    };
+    const deployableQuery = {
+      whereIn: jest.fn(() => deployableQuery),
+      delete: deployableDelete,
+    };
+    const transact = jest.fn(async (callback) => callback(trx));
+    const db = {
+      models: {
+        Deploy: {
+          query: jest.fn(() => deployQuery),
+        },
+        Deployable: {
+          query: jest.fn(() => deployableQuery),
+          transact,
+        },
+      },
+    };
+    const service = createService(db);
+
+    await service.deleteServiceRows({ buildId: 10, deployableIds: [1, 1, 2] });
+
+    expect(transact).toHaveBeenCalledTimes(1);
+    expect(db.models.Deploy.query).toHaveBeenCalledWith(trx);
+    expect(deployQuery.where).toHaveBeenCalledWith({ buildId: 10 });
+    expect(deployQuery.whereIn).toHaveBeenCalledWith('deployableId', [1, 2]);
+    expect(deployDelete).toHaveBeenCalled();
+    expect(db.models.Deployable.query).toHaveBeenCalledWith(trx);
+    expect(deployableQuery.whereIn).toHaveBeenCalledWith('id', [1, 2]);
+    expect(deployableDelete).toHaveBeenCalled();
+  });
+
+  test('deleteServiceRows skips empty deployable id input', async () => {
+    const transact = jest.fn();
+    const service = createService({
+      models: {
+        Deployable: {
+          transact,
+        },
+      },
+    });
+
+    await service.deleteServiceRows({ buildId: 10, deployableIds: [] });
+
+    expect(transact).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/deployable.test.ts
+++ b/src/server/services/__tests__/deployable.test.ts
@@ -14,14 +14,45 @@
  * limitations under the License.
  */
 
-import mockRedisClient from 'server/lib/__mocks__/redisClientMock';
-mockRedisClient();
+const mockGetAllConfigs = jest.fn();
+const mockInstance = {
+  getAllConfigs: (...args: any[]) => mockGetAllConfigs(...args),
+  isFeatureEnabled: jest.fn().mockResolvedValue(false),
+};
+
+jest.mock('server/services/globalConfig', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(() => mockInstance),
+  },
+}));
+
+jest.mock('server/lib/dependencies', () => ({
+  defaultDb: {},
+  defaultRedis: {},
+  defaultRedlock: {},
+  defaultQueueManager: {},
+  redisClient: {
+    getConnection: jest.fn(),
+  },
+}));
+
+jest.mock('server/lib/logger', () => ({
+  getLogger: jest.fn(() => ({
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+  })),
+}));
+
+jest.mock('server/lib/github', () => ({
+  getYamlFileContentFromBranch: jest.fn(),
+}));
 
 import * as YamlService from 'server/models/yaml';
-import GlobalConfigService from 'server/services/globalConfig';
 import DeployableService, { DeployableAttributes } from '../deployable';
-
-jest.mock('server/services/globalConfig');
 
 const lifecycleDefaults = {
   defaultUUID: 'mockedUUID',
@@ -56,21 +87,13 @@ const globalConfigs = {
   domainDefaults: domainDefaults,
 };
 
-const mockedGetAllConfigs = jest.fn().mockResolvedValue(globalConfigs);
-
-const mockedInstance = {
-  getAllConfigs: mockedGetAllConfigs,
-  isFeatureEnabled: jest.fn().mockResolvedValue(false),
-};
-
-(GlobalConfigService.getInstance as jest.Mock).mockReturnValue(mockedInstance);
 describe('Deployable Service', () => {
   describe('generateAttributesFromYamlConfig', () => {
     const deployableService: DeployableService = new DeployableService(null, null, null);
 
     beforeEach(() => {
-      mockedGetAllConfigs.mockResolvedValue(globalConfigs);
-      mockedInstance.isFeatureEnabled.mockResolvedValue(false);
+      mockGetAllConfigs.mockResolvedValue(globalConfigs);
+      mockInstance.isFeatureEnabled.mockResolvedValue(false);
     });
 
     test('Generates from Github Service Type Configuration', async () => {
@@ -156,6 +179,9 @@ describe('Deployable Service', () => {
         buildUUID: 'unit-test-12345',
         buildId: 100,
         repositoryId: '1234567890',
+        resolvedFromRepositoryId: 1234567890,
+        source: 'yaml',
+        reconcileEligible: true,
         branchName: 'unit-test',
         defaultUUID: lifecycleDefaults.defaultUUID,
         dockerfilePath: 'app1/app.Dockerfile',
@@ -318,6 +344,9 @@ describe('Deployable Service', () => {
         buildUUID: 'unit-test-12345',
         buildId: 100,
         repositoryId: '1234567890',
+        resolvedFromRepositoryId: 1234567890,
+        source: 'yaml',
+        reconcileEligible: true,
         branchName: 'unit-test',
         defaultUUID: lifecycleDefaults.defaultUUID,
         dockerfilePath: 'app1/app.Dockerfile',
@@ -432,7 +461,7 @@ describe('Deployable Service', () => {
     });
 
     test('inherits global buildkit engine for Github docker services', async () => {
-      mockedGetAllConfigs.mockResolvedValue({
+      mockGetAllConfigs.mockResolvedValue({
         ...globalConfigs,
         buildDefaults: { engine: 'buildkit' },
       });
@@ -464,7 +493,7 @@ describe('Deployable Service', () => {
     });
 
     test('inherits global buildkit engine for Helm docker services', async () => {
-      mockedGetAllConfigs.mockResolvedValue({
+      mockGetAllConfigs.mockResolvedValue({
         ...globalConfigs,
         buildDefaults: { engine: 'buildkit' },
         'sample-chart': {
@@ -507,7 +536,7 @@ describe('Deployable Service', () => {
     });
 
     test('service builder engine ci overrides global buildkit and persists ci', async () => {
-      mockedGetAllConfigs.mockResolvedValue({
+      mockGetAllConfigs.mockResolvedValue({
         ...globalConfigs,
         buildDefaults: { engine: 'buildkit' },
       });
@@ -542,7 +571,7 @@ describe('Deployable Service', () => {
     });
 
     test('service builder engine kaniko overrides global buildkit', async () => {
-      mockedGetAllConfigs.mockResolvedValue({
+      mockGetAllConfigs.mockResolvedValue({
         ...globalConfigs,
         buildDefaults: { engine: 'buildkit' },
       });

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -37,6 +37,7 @@ import { ParsingError, YamlConfigParser } from 'server/lib/yamlConfigParser';
 import { ValidationError, YamlConfigValidator } from 'server/lib/yamlConfigValidator';
 
 import { type LifecycleYamlConfigOptions } from 'server/models/yaml/types';
+import type { DeployableReconciliationResult } from 'server/services/deployable';
 import { DeploymentManager } from 'server/lib/deploymentManager/deploymentManager';
 import { Tracer } from 'server/lib/tracer';
 import { redisClient } from 'server/lib/dependencies';
@@ -44,6 +45,7 @@ import { generateGraph } from 'server/lib/dependencyGraph';
 import GlobalConfigService from './globalConfig';
 import IngressService from './ingress';
 import AgentPrewarmService from './agentPrewarm';
+import DeployCleanupService from './deployCleanup';
 import { paginate, PaginationMetadata, PaginationParams } from 'server/lib/paginate';
 import { getYamlFileContentFromBranch } from 'server/lib/github';
 import WebhookService from './webhook';
@@ -778,7 +780,7 @@ export default class BuildService extends BaseService {
     // Write the deployables here for now and not going to use them yet.
     try {
       const buildId = build?.id;
-      await this.db.services.Deployable.upsertDeployables(
+      const reconciliationResult = await this.db.services.Deployable.upsertDeployables(
         buildId,
         build.uuid,
         build.pullRequest,
@@ -787,7 +789,7 @@ export default class BuildService extends BaseService {
         filterGithubRepositoryId
       );
 
-      await this.db.services.Webhook.upsertWebhooksWithYaml(build, build.pullRequest);
+      await this.reconcileDeletedDeployables(build, reconciliationResult, filterGithubRepositoryId);
     } catch (error) {
       if (error instanceof ParsingError) {
         getLogger().error({ error }, 'Config: parsing failed');
@@ -799,8 +801,110 @@ export default class BuildService extends BaseService {
         throw error;
       } else {
         getLogger().warn({ error }, 'Config: import warning');
+        throw error;
       }
     }
+
+    await this.db.services.Webhook.upsertWebhooksWithYaml(build, build.pullRequest).catch((error) => {
+      getLogger().warn({ error }, 'Config: webhook import warning');
+    });
+  }
+
+  private async reconcileDeletedDeployables(
+    build: Build,
+    reconciliationResult: DeployableReconciliationResult,
+    filterGithubRepositoryId?: number
+  ) {
+    if (!build?.enableFullYaml || !reconciliationResult?.canReconcile) {
+      return;
+    }
+
+    const reconcileEnabled = await GlobalConfigService.getInstance().isFeatureEnabled('reconcileDeletedServices');
+    if (!reconcileEnabled) {
+      getLogger({ buildUuid: build.uuid }).debug('Stale deploy reconciliation: disabled');
+      return;
+    }
+
+    const buildId = build.id;
+    const expectedDeployables = reconciliationResult.reconcileEligibleDeployables.filter((deployable) => {
+      if (!deployable.reconcileEligible || deployable.source !== 'yaml') {
+        return false;
+      }
+
+      if (filterGithubRepositoryId) {
+        return deployable.resolvedFromRepositoryId === filterGithubRepositoryId;
+      }
+
+      return true;
+    });
+    const expectedNames = new Set(expectedDeployables.map((deployable) => deployable.name));
+
+    let existingQuery = this.db.models.Deployable.query()
+      .where({
+        buildId,
+        buildUUID: build.uuid,
+        reconcileEligible: true,
+        source: 'yaml',
+      })
+      .whereNot('type', DeployTypes.CONFIGURATION);
+
+    if (filterGithubRepositoryId) {
+      existingQuery = existingQuery
+        .where('resolvedFromRepositoryId', filterGithubRepositoryId)
+        .whereNotNull('resolvedFromRepositoryId');
+    }
+
+    const existingDeployables = await existingQuery;
+    const staleDeployables = existingDeployables.filter((deployable) => !expectedNames.has(deployable.name));
+
+    if (staleDeployables.length === 0) {
+      getLogger({
+        buildUuid: build.uuid,
+        filterGithubRepositoryId,
+        expectedCount: expectedNames.size,
+      }).debug('Stale deploy reconciliation: no stale deployables');
+      return;
+    }
+
+    const staleDeployableIds = staleDeployables.map((deployable) => deployable.id);
+    const staleDeploys = await this.db.models.Deploy.query()
+      .where({ buildId })
+      .whereIn('deployableId', staleDeployableIds)
+      .withGraphFetched('[build, service, deployable]');
+    const cleanupService =
+      this.db.services?.DeployCleanupService ||
+      new DeployCleanupService(this.db, this.redis, this.redlock, this.queueManager);
+
+    getLogger({
+      buildUuid: build.uuid,
+      filterGithubRepositoryId,
+      staleDeployableNames: staleDeployables.map((deployable) => deployable.name),
+      staleDeployCount: staleDeploys.length,
+    }).warn('Stale deploy reconciliation: cleaning deleted deployables');
+
+    await Promise.all(
+      staleDeploys.map(async (deploy) => {
+        try {
+          await cleanupService.cleanupDeploy(deploy, { mode: 'service' });
+        } catch (error) {
+          getLogger({
+            error,
+            buildUuid: build.uuid,
+            deployUuid: deploy.uuid,
+            deployableId: deploy.deployableId,
+          }).error('Stale deploy reconciliation: cleanup failed continuing=true');
+        }
+      })
+    );
+
+    await cleanupService.deleteServiceRows({ buildId, deployableIds: staleDeployableIds });
+    await build.$fetchGraph('[deployables, deploys]');
+
+    getLogger({
+      buildUuid: build.uuid,
+      filterGithubRepositoryId,
+      staleDeployableNames: staleDeployables.map((deployable) => deployable.name),
+    }).warn('Stale deploy reconciliation: deleted stale deploy database rows');
   }
 
   public async createBuild(

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -387,6 +387,7 @@ export default class BuildService extends BaseService {
     await this.enqueueResolveAndDeployBuild({
       buildId,
       githubRepositoryId,
+      skipDeletedServiceReconciliation: true,
       runUUID,
       ...extractContextForQueue(),
     });
@@ -776,7 +777,12 @@ export default class BuildService extends BaseService {
     }
   }
 
-  private async importYamlConfigFile(environment: Environment, build: Build, filterGithubRepositoryId?: number) {
+  private async importYamlConfigFile(
+    environment: Environment,
+    build: Build,
+    filterGithubRepositoryId?: number,
+    options: { skipDeletedServiceReconciliation?: boolean } = {}
+  ) {
     // Write the deployables here for now and not going to use them yet.
     try {
       const buildId = build?.id;
@@ -789,7 +795,14 @@ export default class BuildService extends BaseService {
         filterGithubRepositoryId
       );
 
-      await this.reconcileDeletedDeployables(build, reconciliationResult, filterGithubRepositoryId);
+      if (options.skipDeletedServiceReconciliation) {
+        getLogger({
+          buildUuid: build.uuid,
+          filterGithubRepositoryId,
+        }).info('Stale deploy reconciliation: skipped for service redeploy');
+      } else {
+        await this.reconcileDeletedDeployables(build, reconciliationResult, filterGithubRepositoryId);
+      }
     } catch (error) {
       if (error instanceof ParsingError) {
         getLogger().error({ error }, 'Config: parsing failed');
@@ -1796,7 +1809,8 @@ export default class BuildService extends BaseService {
    * @param job the BullMQ job with the buildID
    */
   processBuildQueue = async (job) => {
-    const { buildId, githubRepositoryId, sender, correlationId, _ddTraceContext } = job.data;
+    const { buildId, githubRepositoryId, sender, correlationId, skipDeletedServiceReconciliation, _ddTraceContext } =
+      job.data;
 
     return withLogContext({ correlationId, sender, _ddTraceContext }, async () => {
       let build;
@@ -1814,7 +1828,9 @@ export default class BuildService extends BaseService {
         await build?.$fetchGraph('[pullRequest, environment]');
         await build.pullRequest.$fetchGraph('[repository]');
 
-        await this.importYamlConfigFile(build?.environment, build, githubRepositoryId);
+        await this.importYamlConfigFile(build?.environment, build, githubRepositoryId, {
+          skipDeletedServiceReconciliation,
+        });
 
         await this.db.services.BuildService.resolveAndDeployBuild(
           build,
@@ -1855,7 +1871,7 @@ export default class BuildService extends BaseService {
    * @param done the Bull callback to invoke when we're done
    */
   processResolveAndDeployBuildQueue = async (job) => {
-    const { sender, correlationId, _ddTraceContext } = job.data;
+    const { sender, correlationId, skipDeletedServiceReconciliation, _ddTraceContext } = job.data;
 
     return withLogContext({ correlationId, sender, _ddTraceContext }, async () => {
       let jobId;
@@ -1887,6 +1903,7 @@ export default class BuildService extends BaseService {
         await this.enqueueBuildJob({
           buildId,
           githubRepositoryId,
+          skipDeletedServiceReconciliation,
           ...extractContextForQueue(),
         });
       } catch (error) {

--- a/src/server/services/deployCleanup.ts
+++ b/src/server/services/deployCleanup.ts
@@ -84,11 +84,7 @@ export default class DeployCleanupService extends BaseService {
   deployCleanupQueue: Queue<DeployCleanupQueueJob> = this.queueManager.registerQueue(QUEUE_NAMES.DEPLOY_CLEANUP, {
     connection: redisClient.getConnection(),
     defaultJobOptions: {
-      attempts: 3,
-      backoff: {
-        type: 'exponential',
-        delay: 2000,
-      },
+      attempts: 1,
       removeOnComplete: 100,
       removeOnFail: 100,
     },
@@ -106,7 +102,10 @@ export default class DeployCleanupService extends BaseService {
     const { deployId, mode, sender, correlationId, _ddTraceContext } = job.data;
 
     return withLogContext({ sender, correlationId, _ddTraceContext }, async () => {
-      await this.cleanupDeploy(deployId, { mode });
+      const success = await this.cleanupDeploy(deployId, { mode });
+      if (!success) {
+        throw new Error(`Deploy cleanup failed deployId=${deployId} mode=${mode}`);
+      }
     });
   };
 

--- a/src/server/services/deployCleanup.ts
+++ b/src/server/services/deployCleanup.ts
@@ -1,0 +1,382 @@
+/**
+ * Copyright 2026 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Job, Queue } from 'bullmq';
+import { Deploy } from 'server/models';
+import { shellPromise } from 'server/lib/shell';
+import { extractContextForQueue, getLogger, withLogContext } from 'server/lib/logger';
+import { CLIDeployTypes, DeployStatus, DeployTypes } from 'shared/constants';
+import { codefreshDestroy, deleteDeploy } from 'server/lib/cli';
+import Metrics from 'server/lib/metrics';
+import BaseService from './_service';
+import { parseSecretRefsFromEnv } from 'server/lib/secretRefs';
+import { generateSecretName } from 'server/lib/kubernetes/externalSecret';
+import { QUEUE_NAMES } from 'shared/config';
+import { redisClient } from 'server/lib/dependencies';
+
+export type DeployCleanupMode = 'infra' | 'service';
+
+interface CleanupTask {
+  name: string;
+  resourceType: string;
+  run: () => Promise<unknown>;
+}
+
+interface ServiceDiskConfig {
+  name: string;
+}
+
+interface DeployCleanupQueueJob {
+  deployId: number;
+  mode: 'infra';
+  sender?: string;
+  correlationId?: string;
+  _ddTraceContext?: Record<string, string>;
+}
+
+function shellQuote(value: string | number): string {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function unique<T>(values: Array<T | null | undefined | false>): T[] {
+  return Array.from(new Set(values.filter((value): value is T => Boolean(value))));
+}
+
+function parseServiceDisks(raw: string | null | undefined): ServiceDiskConfig[] {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((disk) => disk?.name) : [];
+  } catch (error) {
+    getLogger({ error }).warn('Deploy cleanup: service disk parse failed');
+    return [];
+  }
+}
+
+function isMissingResourceTypeError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const normalized = message.toLowerCase();
+
+  return (
+    normalized.includes("the server doesn't have a resource type") ||
+    normalized.includes('the server does not have a resource type') ||
+    normalized.includes('no matches for kind')
+  );
+}
+
+export default class DeployCleanupService extends BaseService {
+  deployCleanupQueue: Queue<DeployCleanupQueueJob> = this.queueManager.registerQueue(QUEUE_NAMES.DEPLOY_CLEANUP, {
+    connection: redisClient.getConnection(),
+    defaultJobOptions: {
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 2000,
+      },
+      removeOnComplete: 100,
+      removeOnFail: 100,
+    },
+  });
+
+  async enqueueCleanup({ deployId, mode }: { deployId: number; mode: 'infra' }) {
+    return this.deployCleanupQueue.add('cleanup', {
+      deployId,
+      mode,
+      ...extractContextForQueue(),
+    });
+  }
+
+  processCleanupQueue = async (job: Job<DeployCleanupQueueJob>) => {
+    const { deployId, mode, sender, correlationId, _ddTraceContext } = job.data;
+
+    return withLogContext({ sender, correlationId, _ddTraceContext }, async () => {
+      await this.cleanupDeploy(deployId, { mode });
+    });
+  };
+
+  async cleanupDeploy(deployOrId: Deploy | number, { mode }: { mode: DeployCleanupMode }): Promise<boolean> {
+    const deploy = await this.resolveDeploy(deployOrId);
+    if (!deploy) {
+      getLogger({ deployId: deployOrId, mode }).warn('Deploy cleanup: deploy not found');
+      return false;
+    }
+
+    const metadata = this.resolveCleanupMetadata(deploy);
+    if (!metadata) {
+      getLogger({
+        deployId: deploy.id,
+        deployUuid: deploy.uuid,
+        mode,
+      }).warn('Deploy cleanup: missing deploy metadata');
+      return false;
+    }
+
+    const { namespace, serviceName, deployType } = metadata;
+    return withLogContext({ deployUuid: deploy.uuid, serviceName }, async () => {
+      const metrics = this.metricsFor(deploy, mode);
+      const tasks = [
+        ...this.buildKubernetesTasks(deploy, namespace),
+        ...this.buildSecretTasks(deploy, namespace, serviceName),
+        this.buildHelmTask(deploy, namespace, deployType),
+        this.buildCliTask(deploy, deployType),
+      ].filter(Boolean) as CleanupTask[];
+
+      getLogger({ mode, taskCount: tasks.length }).info('Deploy cleanup: targeted teardown started');
+
+      const results: boolean[] = [];
+      for (const task of tasks) {
+        results.push(await this.runTask(task, deploy, metrics, mode));
+      }
+
+      const success = results.every(Boolean);
+      metrics.increment('deploy', { mode, result: success ? 'complete' : 'partial_failure' });
+
+      if (mode === 'infra' && success) {
+        await deploy.$query().patch({
+          status: DeployStatus.TORN_DOWN,
+          statusMessage: 'Deploy infrastructure was cleaned up successfully',
+        });
+      }
+
+      getLogger({ mode, taskCount: tasks.length, success }).info('Deploy cleanup: targeted teardown complete');
+      return success;
+    });
+  }
+
+  async deleteServiceRows({ buildId, deployableIds }: { buildId: number; deployableIds: number[] }): Promise<void> {
+    const uniqueDeployableIds = unique(deployableIds);
+    if (uniqueDeployableIds.length === 0) {
+      return;
+    }
+
+    await this.db.models.Deployable.transact(async (trx) => {
+      await this.db.models.Deploy.query(trx).where({ buildId }).whereIn('deployableId', uniqueDeployableIds).delete();
+      await this.db.models.Deployable.query(trx).whereIn('id', uniqueDeployableIds).delete();
+    });
+  }
+
+  private async resolveDeploy(deployOrId: Deploy | number): Promise<Deploy | null> {
+    if (typeof deployOrId === 'number') {
+      return (
+        (await this.db.models.Deploy.query().findById(deployOrId).withGraphFetched('[build, service, deployable]')) ??
+        null
+      );
+    }
+
+    await deployOrId.$fetchGraph('[build, service, deployable]');
+    return deployOrId;
+  }
+
+  private resolveCleanupMetadata(
+    deploy: Deploy
+  ): { namespace: string; serviceName: string; deployType: DeployTypes } | null {
+    const namespace = deploy.build?.namespace;
+    const serviceName = deploy.deployable?.name || deploy.service?.name;
+    const deployType = deploy.deployable?.type || deploy.service?.type;
+
+    if (!namespace || !deploy.uuid || !serviceName || !deployType) {
+      return null;
+    }
+
+    return { namespace, serviceName, deployType: deployType as DeployTypes };
+  }
+
+  private metricsFor(deploy: Deploy, mode: DeployCleanupMode): Metrics {
+    return new Metrics('deploy_cleanup', {
+      uuid: deploy?.build?.uuid,
+      tags: {
+        mode,
+        deployUuid: deploy?.uuid,
+        serviceName: deploy?.deployable?.name || deploy?.service?.name,
+      },
+    });
+  }
+
+  private kubectlDeleteExact(resourceType: string, namespace: string, names: string[]): CleanupTask | null {
+    const filteredNames = unique(names);
+    if (filteredNames.length === 0) {
+      return null;
+    }
+
+    return {
+      name: `kubectl-exact-${resourceType}`,
+      resourceType,
+      run: () =>
+        shellPromise(
+          `kubectl delete ${resourceType} ${filteredNames.map(shellQuote).join(' ')} --namespace ${shellQuote(
+            namespace
+          )} --ignore-not-found`
+        ),
+    };
+  }
+
+  private kubectlDeleteBySelector(resourceType: string, namespace: string, selector: string): CleanupTask {
+    return {
+      name: `kubectl-selector-${resourceType}`,
+      resourceType,
+      run: () =>
+        shellPromise(
+          `kubectl delete ${resourceType} --namespace ${shellQuote(namespace)} -l ${shellQuote(
+            selector
+          )} --ignore-not-found`
+        ),
+    };
+  }
+
+  private buildKubernetesTasks(deploy: Deploy, namespace: string): CleanupTask[] {
+    const deployUuid = deploy.uuid;
+    const deployId = deploy.id != null ? String(deploy.id) : null;
+    const deployableId = deploy.deployableId != null ? String(deploy.deployableId) : null;
+    const tasks: CleanupTask[] = [];
+
+    const exactTasks = [
+      this.kubectlDeleteExact('deployment', namespace, [deployUuid]),
+      this.kubectlDeleteExact('service', namespace, [deployUuid, `internal-lb-${deployUuid}`]),
+      this.kubectlDeleteExact('mapping', namespace, [deployUuid]),
+      this.kubectlDeleteExact('ingress', namespace, [`ingress-${deployUuid}`]),
+    ].filter(Boolean) as CleanupTask[];
+    tasks.push(...exactTasks);
+
+    const serviceDisks = parseServiceDisks(deploy.deployable?.serviceDisksYaml);
+    const pvcNames = serviceDisks.map((disk) => `${deployUuid}-${disk.name}-claim`);
+    const pvcTask = this.kubectlDeleteExact('pvc', namespace, pvcNames);
+    if (pvcTask) {
+      tasks.push(pvcTask);
+    }
+
+    const selectors = unique([
+      `deploy_uuid=${deployUuid}`,
+      `lc-deploy-uuid=${deployUuid}`,
+      deployId ? `deploy-id=${deployId}` : null,
+      deployableId ? `deployable-id=${deployableId}` : null,
+    ]);
+
+    for (const resourceType of ['pod', 'job', 'configmap']) {
+      for (const selector of selectors) {
+        tasks.push(this.kubectlDeleteBySelector(resourceType, namespace, selector));
+      }
+    }
+
+    return tasks;
+  }
+
+  private buildSecretTasks(deploy: Deploy, namespace: string, serviceName: string): CleanupTask[] {
+    const envRefs = parseSecretRefsFromEnv(deploy.env as Record<string, string>);
+    const initEnvRefs = parseSecretRefsFromEnv(deploy.initEnv as Record<string, string>);
+    const providers = unique([...envRefs, ...initEnvRefs].map((ref) => ref.provider));
+
+    return providers.flatMap((provider) => {
+      const secretName = generateSecretName(serviceName, provider);
+      return [
+        {
+          name: `externalsecret-${provider}`,
+          resourceType: 'externalsecret',
+          run: () =>
+            shellPromise(
+              `kubectl delete externalsecret ${shellQuote(secretName)} --namespace ${shellQuote(
+                namespace
+              )} --ignore-not-found`
+            ),
+        },
+        {
+          name: `secret-${provider}`,
+          resourceType: 'secret',
+          run: () =>
+            shellPromise(
+              `kubectl delete secret ${shellQuote(secretName)} --namespace ${shellQuote(namespace)} --ignore-not-found`
+            ),
+        },
+      ];
+    });
+  }
+
+  private buildHelmTask(deploy: Deploy, namespace: string, deployType: DeployTypes): CleanupTask | null {
+    if (deployType !== DeployTypes.HELM) {
+      return null;
+    }
+
+    return {
+      name: 'helm-uninstall',
+      resourceType: 'helm-release',
+      run: () => shellPromise(`helm uninstall ${shellQuote(deploy.uuid)} --namespace ${shellQuote(namespace)}`),
+    };
+  }
+
+  private buildCliTask(deploy: Deploy, deployType: DeployTypes): CleanupTask | null {
+    if (!CLIDeployTypes.has(deployType)) {
+      return null;
+    }
+
+    return {
+      name: 'cli-destroy',
+      resourceType: deployType,
+      run: () => (deployType === DeployTypes.CODEFRESH ? codefreshDestroy(deploy) : deleteDeploy(deploy)),
+    };
+  }
+
+  private async runTask(
+    task: CleanupTask,
+    deploy: Deploy,
+    metrics: Metrics,
+    mode: DeployCleanupMode
+  ): Promise<boolean> {
+    try {
+      await task.run();
+      metrics.increment('task', {
+        mode,
+        result: 'success',
+        resourceType: task.resourceType,
+      });
+      return true;
+    } catch (error) {
+      if (isMissingResourceTypeError(error)) {
+        metrics.increment('task', {
+          mode,
+          result: 'skipped_missing_resource_type',
+          resourceType: task.resourceType,
+        });
+        getLogger({
+          mode,
+          deployUuid: deploy.uuid,
+          deployId: deploy.id,
+          deployableId: deploy.deployableId,
+          resourceType: task.resourceType,
+          task: task.name,
+        }).debug('Deploy cleanup: skipped missing Kubernetes resource type');
+        return true;
+      }
+
+      metrics.increment('task', {
+        mode,
+        result: 'error',
+        resourceType: task.resourceType,
+      });
+      getLogger({
+        error,
+        mode,
+        deployUuid: deploy.uuid,
+        deployId: deploy.id,
+        deployableId: deploy.deployableId,
+        resourceType: task.resourceType,
+        task: task.name,
+      }).error('Deploy cleanup: targeted teardown failed');
+      return false;
+    }
+  }
+}

--- a/src/server/services/deployable.ts
+++ b/src/server/services/deployable.ts
@@ -24,6 +24,22 @@ import { CAPACITY_TYPE, DeployTypes } from 'shared/constants';
 import { Builder, Helm } from 'server/models/yaml';
 import GlobalConfigService from './globalConfig';
 
+export type DeployableConfigSource = 'yaml' | 'db' | 'db-yaml-merged';
+
+export interface DeployableReconciliationEntry {
+  name: string;
+  source: DeployableConfigSource;
+  reconcileEligible: boolean;
+  resolvedFromRepositoryId?: number | null;
+}
+
+export interface DeployableReconciliationResult {
+  deployables: Deployable[];
+  canReconcile: boolean;
+  reconcileEligibleDeployables: DeployableReconciliationEntry[];
+  filterGithubRepositoryId?: number | null;
+}
+
 export interface DeployableAttributes {
   appShort?: string;
   ecr?: string;
@@ -96,9 +112,16 @@ export interface DeployableAttributes {
   envLens?: boolean;
   nodeSelector?: Record<string, string>;
   nodeAffinity?: Record<string, unknown>;
+  source?: DeployableConfigSource;
+  reconcileEligible?: boolean;
+  resolvedFromRepositoryId?: number | null;
 }
 
 export default class DeployableService extends BaseService {
+  private isYamlReconcileEligible(type: string): boolean {
+    return type !== DeployTypes.CONFIGURATION;
+  }
+
   /**
    *
    * @param buildId
@@ -127,6 +150,7 @@ export default class DeployableService extends BaseService {
         type: service.type,
         dockerImage: service.dockerImage,
         repositoryId: service.repositoryId,
+        resolvedFromRepositoryId: service.repositoryId != null ? Number(service.repositoryId) : null,
         defaultTag: service.defaultTag,
         dockerfilePath: service.dockerfilePath,
         // buildArgs: NOT IN USE
@@ -179,6 +203,8 @@ export default class DeployableService extends BaseService {
         defaultBranchName: service.branchName,
         nodeSelector: service.nodeSelector ?? null,
         nodeAffinity: service.nodeAffinity ?? null,
+        source: 'db',
+        reconcileEligible: false,
       };
 
       if (branch != null) {
@@ -307,6 +333,7 @@ export default class DeployableService extends BaseService {
           type: YamlService.getDeployType(service),
           dockerImage: YamlService.getDockerImage(service),
           repositoryId: repositoryId ?? null,
+          resolvedFromRepositoryId: repositoryId != null ? Number(repositoryId) : null,
           branchName,
           defaultBranchName,
           defaultTag: await YamlService.getDefaultTag(service),
@@ -376,6 +403,8 @@ export default class DeployableService extends BaseService {
           deploymentDependsOn: service.deploymentDependsOn || [],
           builder: YamlService.getEffectiveBuilder(service, buildDefaults?.engine) ?? {},
           envLens: await YamlService.getEnvLens(service),
+          source: 'yaml',
+          reconcileEligible: this.isYamlReconcileEligible(YamlService.getDeployType(service)),
         };
       }
     } catch (error) {
@@ -449,24 +478,26 @@ export default class DeployableService extends BaseService {
           const yamlService: YamlService.Service = YamlService.getDeployingServicesByName(yamlConfig, service.name);
           if (yamlService != null) {
             const serviceRepositoryId = await this.determineRepositoryId(service, build);
-            deployableServices.set(
-              service.name,
-              this.mergeDeployableAttributes(
-                buildUUID,
-                service,
-                await this.generateAttributesFromYamlConfig(
-                  buildId,
-                  buildUUID,
-                  serviceRepositoryId,
-                  branchName,
-                  yamlService,
-                  true,
-                  null,
-                  build
-                ),
-                deployableServices.get(service.name)
-              )
+            const yamlAttributes = await this.generateAttributesFromYamlConfig(
+              buildId,
+              buildUUID,
+              serviceRepositoryId,
+              branchName,
+              yamlService,
+              true,
+              null,
+              build
             );
+            const mergedAttributes = this.mergeDeployableAttributes(
+              buildUUID,
+              service,
+              yamlAttributes,
+              deployableServices.get(service.name)
+            );
+            mergedAttributes.source = 'db-yaml-merged';
+            mergedAttributes.reconcileEligible = false;
+            mergedAttributes.resolvedFromRepositoryId = serviceRepositoryId ?? null;
+            deployableServices.set(service.name, mergedAttributes);
           }
         }
       }
@@ -755,8 +786,9 @@ export default class DeployableService extends BaseService {
     pullRequest: PullRequest,
     build?: Build,
     filterGithubRepositoryId?: number
-  ) {
+  ): Promise<boolean> {
     try {
+      let allReferencedYamlConfigsResolved = true;
       let filterRepositoryFullName: string | null = null;
       if (filterGithubRepositoryId) {
         const filterRepo = await this.db.models.Repository.query().findOne({
@@ -907,6 +939,7 @@ export default class DeployableService extends BaseService {
                         );
                       }
                     } else {
+                      allReferencedYamlConfigsResolved = false;
                       getLogger({ buildUUID, deployUUID: deploy?.uuid, repository: repository?.fullName }).warn(
                         `Unable to locate YAML config file from ${repository?.fullName}:${branchName}. Is this a database service?`
                       );
@@ -933,7 +966,7 @@ export default class DeployableService extends BaseService {
         }
       };
 
-      if (pullRequest == null) return;
+      if (pullRequest == null) return false;
 
       await pullRequest.$fetchGraph('[build.[deploys.[deployable], environment], repository]');
       if (pullRequest.repository != null && pullRequest.branchName != null) {
@@ -982,10 +1015,12 @@ export default class DeployableService extends BaseService {
               );
             }
           }
+          return allReferencedYamlConfigsResolved;
         }
       } else {
         getLogger({ buildUUID }).warn('PR: branch name missing');
       }
+      return false;
     } catch (error) {
       getLogger({ buildUUID, error }).error('Deployable: create/update from yaml failed');
       throw error;
@@ -1007,9 +1042,10 @@ export default class DeployableService extends BaseService {
     environment: Environment,
     build?: Build,
     filterGithubRepositoryId?: number
-  ): Promise<Deployable[]> {
+  ): Promise<DeployableReconciliationResult> {
     // We are going to ingest all the database and yaml configuration and process in the memory before writes into the database
-    let deployables: Deployable[];
+    let deployables: Deployable[] = [];
+    let canReconcile = false;
 
     // Temporary storage for all the deployable configurations in memory
     const deployableServices: Map<string, DeployableAttributes> = new Map<string, DeployableAttributes>();
@@ -1031,7 +1067,7 @@ export default class DeployableService extends BaseService {
 
         // Next read the YAML config file from the PR's repository and branch
         // Overwrite the db config exists in the YAML + any YAML only configurations
-        await this.updateOrCreateDeployableUsingYamlConfig(
+        canReconcile = await this.updateOrCreateDeployableUsingYamlConfig(
           deployableServices,
           buildId,
           buildUUID,
@@ -1058,7 +1094,19 @@ export default class DeployableService extends BaseService {
       throw error;
     }
     getLogger({ buildUUID }).info(`Deployable: upserted count=${deployables.length}`);
-    return deployables;
+    return {
+      deployables,
+      canReconcile,
+      filterGithubRepositoryId: filterGithubRepositoryId ?? null,
+      reconcileEligibleDeployables: Array.from(deployableServices.values())
+        .filter((deployable) => deployable.reconcileEligible)
+        .map((deployable) => ({
+          name: deployable.name,
+          source: deployable.source ?? 'db',
+          reconcileEligible: deployable.reconcileEligible ?? false,
+          resolvedFromRepositoryId: deployable.resolvedFromRepositoryId ?? null,
+        })),
+    };
   }
 
   /**

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -30,6 +30,7 @@ import BotUser from 'server/services/botUser';
 import GlobalConfig from 'server/services/globalConfig';
 import LabelService from 'server/services/label';
 import TTLCleanupService from 'server/services/ttlCleanup';
+import DeployCleanupService from 'server/services/deployCleanup';
 import { IServices } from 'server/services/types';
 
 export default function createAndBindServices(): IServices {
@@ -50,5 +51,6 @@ export default function createAndBindServices(): IServices {
     GlobalConfig: GlobalConfig.getInstance(),
     LabelService: new LabelService(),
     TTLCleanupService: new TTLCleanupService(),
+    DeployCleanupService: new DeployCleanupService(),
   };
 }

--- a/src/server/services/types/index.ts
+++ b/src/server/services/types/index.ts
@@ -30,6 +30,7 @@ import GlobalConfig from 'server/services/globalConfig';
 import GithubService from 'server/services/github';
 import LabelService from 'server/services/label';
 import TTLCleanupService from 'server/services/ttlCleanup';
+import DeployCleanupService from 'server/services/deployCleanup';
 
 export interface IServices {
   BuildService: BuildService;
@@ -48,6 +49,7 @@ export interface IServices {
   GlobalConfig: GlobalConfig;
   LabelService: LabelService;
   TTLCleanupService: TTLCleanupService;
+  DeployCleanupService: DeployCleanupService;
 }
 
 export * from 'server/services/types/github';

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -115,6 +115,7 @@ export const QUEUE_NAMES = {
   RESOLVE_AND_DEPLOY: `resolve_and_deploy_${JOB_VERSION}`,
   BUILD_QUEUE: `build_queue_${JOB_VERSION}`,
   GITHUB_DEPLOYMENT: `github_deployment_${JOB_VERSION}`,
+  DEPLOY_CLEANUP: `deploy_cleanup_${JOB_VERSION}`,
   LABEL: `label_${JOB_VERSION}`,
   AGENT_SESSION_CLEANUP: 'agent_session_cleanup',
   AGENT_SESSION_PREWARM: 'agent_session_prewarm',


### PR DESCRIPTION
## Summary

- add YAML ownership metadata on deployables so stale reconciliation only touches YAML-owned services
- reconcile deleted/renamed YAML services behind `features.reconcileDeletedServices`
- add `DeployCleanupService` for deploy-scoped infra cleanup and stale service row deletion
- wire an async deploy cleanup queue for future infra-only cleanup callers
- skip deleted-service reconciliation for selective service redeploys by passing `skipDeletedServiceReconciliation` through the API redeploy, resolve queue, and build queue path

## Safety

- service renames are treated as delete + create; no rename inference
- repo-filtered reconciliation is limited to matching `resolvedFromRepositoryId`
- ambiguous `repositoryId = null` deployables are skipped during repo-filtered reconciliation
- full config reconciliation may delete YAML-owned `repositoryId = null` deployables after YAML import succeeds
- DB-primary, merged DB/YAML, and `configuration` deployables are excluded from stale cleanup
- deploy cleanup uses deploy-scoped resource names/selectors only; no namespace/build-wide cleanup helpers
- selective service redeploys are not treated as authoritative deleted-service reconciliation scopes

## Tests

- generalized BuildService stale reconciliation tests for:
  - feature flag disabled
  - deleted YAML-owned service cleanup
  - renamed YAML service cleanup
  - repo-filtered cleanup preserving other repository scopes
  - full cleanup of YAML-owned `repositoryId = null` services
  - repo-filtered skip for ambiguous null repository ownership
  - non-authoritative YAML import skip
  - YAML-owned non-configuration query scope
  - cleanup failure still deleting stale DB rows
  - selective service redeploy skipping stale reconciliation
  - selective service redeploy preserving the skip flag through resolve/build queues
- generalized DeployCleanupService tests for:
  - deploy-scoped Kubernetes, Helm, secret, and CLI cleanup
  - no service-name-only selector or build-wide cleanup usage
  - infra mode marks deploy `torn_down` only on full success
  - partial infra failure leaves status unchanged
  - service mode continues after partial teardown failure
  - stale service DB rows are deleted in one transaction

## Validation

- `pnpm run lint` passed
- `pnpm exec jest src/server/services/__tests__/build.test.ts --runInBand` passed
- `pnpm run test -- src/server/services/__tests__/build.test.ts src/server/services/__tests__/deployCleanup.test.ts src/server/services/__tests__/deployable.test.ts` passed
- `BUILD_MODE=yes DATABASE_URL=postgresql://lifecycle:lifecycle@localhost:5434/lifecycle APP_DB_HOST=localhost APP_DB_PORT=5434 APP_DB_USER=lifecycle APP_DB_PASSWORD=lifecycle APP_DB_NAME=lifecycle APP_DB_SSL=false pnpm run test` passed
- `pnpm run ts-check` was run and still fails with repo-wide existing TypeScript strictness errors unrelated to the stale reconciliation changes
- `pnpm exec jest --runInBand` was run after the final redeploy-path fix and failed in this shell because many suites require `DATABASE_URL` / APP DB env; focused regression tests passed
