### PR TITLE
fix: enforce static node affinity for native Helm

### DIFF
--- a/src/server/lib/nativeHelm/__tests__/helm.test.ts
+++ b/src/server/lib/nativeHelm/__tests__/helm.test.ts
@@ -903,6 +903,45 @@ describe('Native Helm', () => {
       expect(customValues).toContain('ingress.ipAllowlist[1]=2.2.2.2/32');
     });
 
+    it('adds static node affinity and tolerations for static org charts', async () => {
+      const deploy = {
+        uuid: 'test-uuid',
+        dockerImage: 'repo/app:tag',
+        env: {},
+        deployable: {
+          buildUUID: 'build-123',
+          port: 8080,
+          helm: {
+            chart: { name: 'lifecycle-app', values: [] },
+            docker: {
+              app: {},
+            },
+          },
+        },
+        build: {
+          commentRuntimeEnv: {},
+          isStatic: true,
+        },
+      } as any;
+
+      const customValues = await constructHelmCustomValues(deploy, ChartType.ORG_CHART);
+
+      expect(customValues).toContain(
+        'deployment.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=eks.amazonaws.com/capacityType'
+      );
+      expect(customValues).toContain(
+        'deployment.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=ON_DEMAND'
+      );
+      expect(customValues).toContain(
+        'deployment.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].key=app-long'
+      );
+      expect(customValues).toContain(
+        'deployment.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].values[0]=lifecycle-static-env'
+      );
+      expect(customValues).toContain('deployment.tolerations[0].key=static_env');
+      expect(customValues).toContain('deployment.tolerations[0].value=yes');
+    });
+
     it('extracts secret-backed chart values after final value precedence is applied', async () => {
       mockGetAllConfigs.mockResolvedValue({
         postgresql: {

--- a/src/server/lib/nativeHelm/utils.ts
+++ b/src/server/lib/nativeHelm/utils.ts
@@ -798,6 +798,9 @@ export async function constructHelmCustomValueConfiguration(
           `${resourceType}.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=eks.amazonaws.com/capacityType`,
           `${resourceType}.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In`,
           `${resourceType}.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=ON_DEMAND`,
+          `${resourceType}.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].key=app-long`,
+          `${resourceType}.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].operator=In`,
+          `${resourceType}.customNodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].values[0]=lifecycle-static-env`,
           ...generateTolerationsCustomValues(`${resourceType}.tolerations`, staticEnvTolerations),
         ])
       );


### PR DESCRIPTION
## Summary
- Add the missing static node affinity expression for native Helm application-chart deployments.
- Keep the existing ON_DEMAND affinity and static toleration behavior.
- Add test coverage for static scheduling values.

## Validation
- pnpm exec jest src/server/lib/nativeHelm/__tests__/helm.test.ts --runInBand
- pnpm run lint
- pnpm test
- pnpm run ts-check (fails on existing repo-wide TypeScript errors unrelated to this change)