### PR TITLE
fix site upload body limit

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,12 @@
 
 require('dotenv').config();
 
+const SITES_UPLOAD_BODY_LIMIT_BYTES = 200 * 1000 * 1000;
+
 module.exports = {
+  experimental: {
+    middlewareClientMaxBodySize: SITES_UPLOAD_BODY_LIMIT_BYTES,
+  },
   serverExternalPackages: [
     '@kubernetes/client-node',
     '@octokit/core',

--- a/next.config.test.js
+++ b/next.config.test.js
@@ -1,0 +1,8 @@
+const nextConfig = require('./next.config');
+
+describe('next config', () => {
+  it('allows multipart uploads larger than the default request body clone limit', () => {
+    expect(nextConfig.experimental?.middlewareClientMaxBodySize).toBe(200 * 1000 * 1000);
+    expect(nextConfig.experimental?.middlewareClientMaxBodySize).toBeGreaterThan(10 * 1024 * 1024);
+  });
+});


### PR DESCRIPTION
## Summary

- Increase the framework request body clone limit for multipart site uploads.
- Add a regression test for the upload-related framework configuration.

## Validation

- `pnpm run lint`
- `pnpm exec jest next.config.test.js --runInBand`
- `pnpm run ts-check` was attempted; it fails on existing base-branch type errors.
- `pnpm test` was attempted; it requires local database configuration and the same failure was reproduced on the base branch.
