### PR TITLE
fix: remove redundant isSynchronized deploy handler to prevent concurrent builds

### DIFF
--- a/src/server/services/__tests__/github.test.ts
+++ b/src/server/services/__tests__/github.test.ts
@@ -326,34 +326,6 @@ describe('Github Service - handlePullRequestHook', () => {
     expect(mockDb.services.LabelService.labelQueue.add).not.toHaveBeenCalled();
   });
 
-  test('queues a build when an open deployed PR receives a synchronize event', async () => {
-    mockHasDeployLabel.mockResolvedValue(true);
-    mockEnableKillSwitch.mockResolvedValue(false);
-
-    const mockPullRequest = createMockPullRequest({
-      deployOnUpdate: true,
-      latestCommit: 'previous-commit',
-    });
-    mockDb.services.PullRequest.findOrCreatePullRequest.mockResolvedValue(mockPullRequest);
-
-    await githubService.handlePullRequestHook(
-      createMockPullRequestEvent({
-        action: 'synchronize',
-        labels: [{ name: 'lifecycle-deploy!' }],
-        branchSha: 'latest-commit',
-      })
-    );
-
-    expect(mockGetYamlFileContent).not.toHaveBeenCalled();
-    expect(mockDb.services.BuildService.createBuildAndDeploys).not.toHaveBeenCalled();
-    expect(mockPullRequest.__patch).toHaveBeenCalledWith({ latestCommit: 'latest-commit' });
-    expect(mockDb.models.Build.findOne).toHaveBeenCalledWith({ pullRequestId: 1 });
-    expect(mockDb.services.BuildService.resolveAndDeployBuildQueue.add).toHaveBeenCalledWith('resolve-deploy', {
-      buildId: 10,
-      triggerRef: 'latest-commit',
-    });
-  });
-
   test('keeps the existing label sync flow for unlabeled autoDeploy PRs', async () => {
     mockGetYamlFileContent.mockResolvedValue({ environment: { autoDeploy: true } });
     mockHasDeployLabel.mockResolvedValue(false);

--- a/src/server/services/__tests__/github.test.ts
+++ b/src/server/services/__tests__/github.test.ts
@@ -350,6 +350,7 @@ describe('Github Service - handlePullRequestHook', () => {
     expect(mockDb.models.Build.findOne).toHaveBeenCalledWith({ pullRequestId: 1 });
     expect(mockDb.services.BuildService.resolveAndDeployBuildQueue.add).toHaveBeenCalledWith('resolve-deploy', {
       buildId: 10,
+      triggerRef: 'latest-commit',
     });
   });
 

--- a/src/server/services/github.ts
+++ b/src/server/services/github.ts
@@ -155,7 +155,6 @@ export default class GithubService extends Service {
       action as GithubPullRequestActions
     );
     const isClosed = action === GithubPullRequestActions.CLOSED;
-    const isSynchronized = action === GithubPullRequestActions.SYNCHRONIZE;
     let lifecycleConfig = {} as LifecycleYamlConfigOptions;
     let pullRequest: PullRequest, repository: Repository | undefined, build: Build;
 
@@ -277,39 +276,6 @@ export default class GithubService extends Service {
           action: 'disable',
           waitForComment: false,
           labels: labels.map((l) => l.name),
-          ...extractContextForQueue(),
-        });
-      } else if (isSynchronized) {
-        if (branchSha && latestCommit !== branchSha) {
-          await pullRequest.$query().patch({ latestCommit: branchSha });
-        }
-
-        if (status !== PullRequestStatus.OPEN || pullRequestState?.deployOnUpdate !== true) {
-          getLogger({}).info(
-            `PR sync decision: repo=${fullName} branch=${branch} pullRequestId=${pullRequestId} decision=no-deploy deployOnUpdate=${pullRequestState?.deployOnUpdate}`
-          );
-          return;
-        }
-
-        build = await this.db.models.Build.findOne({
-          pullRequestId,
-        });
-        if (!build) {
-          getLogger({}).warn(`Build: not found for synchronized PR repo=${fullName}/${branch}`);
-          return;
-        }
-
-        getLogger({}).info(
-          `PR sync decision: repo=${fullName} branch=${branch} pullRequestId=${pullRequestId} decision=queue-build`
-        );
-        await this.db.services.BuildService.enqueueResolveAndDeployBuild({
-          buildId: build.id,
-          // Mirror the triggerRef strategy from the push handler (PR #218): include the commit SHA in the dedupe key
-          // so back-to-back synchronize events for distinct commits each get their own key instead of collapsing onto
-          // the in-flight key of an earlier commit. Note: push and synchronize fingerprints still differ when the push
-          // path passes githubRepositoryId (the normal case), so the two events run concurrently; they only coalesce
-          // when push also omits githubRepositoryId (e.g. the failed-deploy rebuild path).
-          ...(branchSha ? { triggerRef: branchSha } : {}),
           ...extractContextForQueue(),
         });
       }

--- a/src/server/services/github.ts
+++ b/src/server/services/github.ts
@@ -304,10 +304,11 @@ export default class GithubService extends Service {
         );
         await this.db.services.BuildService.enqueueResolveAndDeployBuild({
           buildId: build.id,
-          // Pass the same commit SHA the concurrent push event uses as triggerRef so both events produce the same
-          // dedupe key and coalesce to one resolveAndDeployBuild run. Without this the push path (added in PR #218)
-          // carries a triggerRef while the synchronize path does not, giving them different keys and causing two
-          // concurrent runs for every PR branch push.
+          // Mirror the triggerRef strategy from the push handler (PR #218): include the commit SHA in the dedupe key
+          // so back-to-back synchronize events for distinct commits each get their own key instead of collapsing onto
+          // the in-flight key of an earlier commit. Note: push and synchronize fingerprints still differ when the push
+          // path passes githubRepositoryId (the normal case), so the two events run concurrently; they only coalesce
+          // when push also omits githubRepositoryId (e.g. the failed-deploy rebuild path).
           ...(branchSha ? { triggerRef: branchSha } : {}),
           ...extractContextForQueue(),
         });

--- a/src/server/services/github.ts
+++ b/src/server/services/github.ts
@@ -304,6 +304,11 @@ export default class GithubService extends Service {
         );
         await this.db.services.BuildService.enqueueResolveAndDeployBuild({
           buildId: build.id,
+          // Pass the same commit SHA the concurrent push event uses as triggerRef so both events produce the same
+          // dedupe key and coalesce to one resolveAndDeployBuild run. Without this the push path (added in PR #218)
+          // carries a triggerRef while the synchronize path does not, giving them different keys and causing two
+          // concurrent runs for every PR branch push.
+          ...(branchSha ? { triggerRef: branchSha } : {}),
           ...extractContextForQueue(),
         });
       }


### PR DESCRIPTION
## Problem

PR #205 added a `pull_request synchronize` handler that calls `enqueueResolveAndDeployBuild` whenever a PR branch receives new commits. The intent was to ensure PR environments rebuild on push, but the `push` event handler already covers this completely.

`deployable.defaultBranchName` stores the **literal yaml value** (`@branch`, `main`, etc.) — never the resolved PR branch name. This means `shouldBuild` in the push handler is always `true` for PR environments:

```
serviceBranchName = "@branch"      →  shouldBuild = ("@branch" !== "feature/my-pr") = true ✅
serviceBranchName = "main"         →  shouldBuild = ("main"    !== "feature/my-pr") = true ✅
```

Every service in the environment is already rebuilt by the push handler. The synchronize handler was redundant.

## Impact

Having both handlers enqueue for the same commit produces two concurrent `resolveAndDeployBuild` runs that race for `runUUID` ownership. If the losing run encounters any error, `recordBuildFailure` force-patches `runUUID` and writes `ERROR` status — even though the winning run's services are healthy. This is the root cause of PR environments appearing failed in the UI when all services are actually running.

## Fix

Remove the `isSynchronized` block from `handlePullRequestHook` and its now-unused `isSynchronized` variable. Remove the corresponding test.

## Test plan

- [x] All 350 tests pass
- [x] Lint clean
- [ ] Validate on staging: push a commit to a PR env branch, confirm only one `resolveAndDeployBuild` run fires (single `runUUID` in Groundcover logs, no duplicate K8s build jobs)