### PR TITLE
fix(mcp): import MCP handler statically so the prod build emits it

### DIFF
--- a/ws-server.ts
+++ b/ws-server.ts
@@ -36,6 +36,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { rootLogger } from './src/server/lib/logger';
 import { LIFECYCLE_MODE } from './src/shared/config';
 import { isMcpServerEnabled, isAuthEnabled } from './src/server/mcp/config';
+import { handleMcpHttpRequest as mcpHttpRequestHandler } from './src/server/mcp/handler';
 import { streamK8sLogs, AbortHandle } from './src/server/lib/k8sStreamer';
 import SitesService from './src/server/services/sites';
 import {
@@ -84,14 +85,15 @@ const SESSION_WORKSPACE_EDITOR_COOKIE_NAME = 'lfc_session_workspace_editor_auth'
 const SESSION_WORKSPACE_EDITOR_PORT = parseInt(process.env.AGENT_SESSION_WORKSPACE_EDITOR_PORT || '13337', 10);
 const logger = rootLogger.child({ filename: __filename });
 
-// jose (an MCP auth dependency) is ESM-only and loads via require(esm), which needs
-// Node >= 20.19. Loading the handler only when the feature is on keeps older Node 20
-// minors booting with MCP disabled.
 type McpHttpHandler = (
   req: IncomingMessage,
   res: ServerResponse,
   pathname: string | null | undefined
 ) => Promise<boolean>;
+// The MCP feature flag still gates whether the handler is *wired up*; the module
+// itself is imported statically. (It was previously loaded via a deferred require to
+// keep the ESM-only jose / MCP SDK off the boot path on Node < 20.19, but all deploys
+// now run Node 22 — where require(esm) is supported — so the workaround is unnecessary.)
 let handleMcpHttpRequest: McpHttpHandler | null = null;
 if (isMcpServerEnabled()) {
   if (isAuthEnabled() && !process.env.MCP_RESOURCE_URL) {
@@ -100,7 +102,7 @@ if (isMcpServerEnabled()) {
         'token audiences will be validated against a localhost default and all real tokens will be rejected'
     );
   }
-  handleMcpHttpRequest = require('./src/server/mcp/handler').handleMcpHttpRequest as McpHttpHandler;
+  handleMcpHttpRequest = mcpHttpRequestHandler;
 }
 let sitesGatewayService: SitesService | null = null;
 


### PR DESCRIPTION
## Summary

Fixes the prod boot crash for the MCP server merged in #224. With `MCP_SERVER_ENABLED=true`, `lifecycle-web` pods crashloop at startup:

```
Error: Cannot find module './src/server/mcp/handler'
    at Object.<anonymous> (/app/.next/ws-server.js:87:28)
```

### Root cause

`ws-server.ts` loaded the MCP handler via a **deferred** `require('./src/server/mcp/handler')`. Because that dynamic require is outside tsc's static import graph, `tsc -p tsconfig.server.json` never compiled the module into `.next/` — so at boot the require of the never-emitted `handler.js` throws. (Local dev via `ts-node` and jest imports from `src` both resolve it, so only the prod build + `MCP_SERVER_ENABLED=true` exposed it.)

### Why the deferred require is no longer needed

It existed solely to keep the ESM-only `jose` / MCP SDK off the boot path on **Node < 20.19** (which can't `require()` ESM). That was a real concern when the MCP alphas shipped on `node:20-slim` — but #223 moved every build to `node:22-slim` **before** this code reached `main`. Since the Docker image welds the Node runtime to the app code, there is no artifact combining "MCP code + Node 20": old Node-20 images predate MCP entirely, and every MCP-carrying image is Node 22 (where `require(esm)` works). The workaround guards a state that can't occur.

### Fix

Import the handler **statically**. tsc traces it through `ws-server.ts`'s import graph and emits it normally, removing the build-vs-runtime gap at the root — no `tsconfig.server.json` `include` entry or build-time guard needed. The `MCP_SERVER_ENABLED` flag still gates whether the handler is *wired up*; only the module *load* moves to boot (a plain `require` on Node 22). Worker / MCP-off pods now load jose+SDK at boot too — negligible on Node 22.

## Validation

- `tsc -p tsconfig.server.json` now emits `.next/src/server/mcp/handler.js` (+ `auth.js`, `server.js`, `truncate.js`) via the static graph; confirmed **absent** before this change, reproducing the crash.
- Server typecheck (`tsconfig.server.json`) exit 0; `pnpm run lint` clean; MCP unit tests match `main` baseline (build/boot-path change, no test impact).

Deploy: once merged, cut a fresh alpha from `main` and roll `lifecycle-web` — the prod realm and web env (`MCP_SERVER_ENABLED`, `MCP_RESOURCE_URL`) are already in place.