### PR TITLE
fix: getEnvironmentsToBuild queried a relation removed in phase 1

### DIFF
--- a/src/server/services/__tests__/build.test.ts
+++ b/src/server/services/__tests__/build.test.ts
@@ -2362,12 +2362,11 @@ describe('BuildService focused changed-line coverage', () => {
     expect(deployUpdate.where).toHaveBeenCalledWith('runUUID', 'build-run');
   });
 
-  test('resolves direct and repository-derived build environments', async () => {
+  test('resolves direct build environments and no longer derives them from the repository', async () => {
     const direct = { id: 5 };
-    const related = [{ id: 6 }];
     const repositoryQuery: any = {
       withGraphJoined: jest.fn(() => repositoryQuery),
-      where: jest.fn().mockResolvedValue(related),
+      where: jest.fn().mockResolvedValue([{ id: 6 }]),
     };
     const service = serviceWith({
       models: {
@@ -2378,8 +2377,13 @@ describe('BuildService focused changed-line coverage', () => {
       },
     });
 
-    await expect((service as any).getEnvironmentsToBuild(5, 9)).resolves.toEqual([direct]);
-    await expect((service as any).getEnvironmentsToBuild(undefined, 9)).resolves.toEqual(related);
+    await expect((service as any).getEnvironmentsToBuild(5)).resolves.toEqual([direct]);
+
+    // The repository-derived lookup joined Environment.services, a relation removed with the
+    // legacy DB-config path. It is only reachable when the repository has no defaultEnvId, in
+    // which case no environment could match anyway, so the lookup is gone rather than repaired.
+    await expect((service as any).getEnvironmentsToBuild(undefined)).resolves.toStrictEqual([]);
+    expect(repositoryQuery.withGraphJoined).not.toHaveBeenCalled();
   });
 
   test('creates missing PR builds with and without a root repository identity', async () => {

--- a/src/server/services/__tests__/build.test.ts
+++ b/src/server/services/__tests__/build.test.ts
@@ -730,6 +730,54 @@ describe('BuildService destroyBuildEnvironment', () => {
   });
 });
 
+describe('BuildService getEnvironmentsToBuild', () => {
+  const createService = (foundEnvironment: any) =>
+    new BuildService(
+      {
+        models: {
+          Environment: {
+            findOne: jest.fn().mockResolvedValue(foundEnvironment),
+            // Phase 1 removed Environment.relationMappings.services. The old else-branch called
+            // Environment.find().withGraphJoined('services'), which throws UnknownRelationError.
+            find: jest.fn(() => {
+              throw new Error('Environment.find() must not be called: the DB-service lookup was removed');
+            }),
+          },
+        },
+      } as any,
+      {} as any,
+      {} as any,
+      {
+        registerQueue: jest.fn(() => ({ add: jest.fn(), process: jest.fn(), on: jest.fn() })),
+      } as any
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns the environment for a known environmentId', async () => {
+    const environment = { id: 7 };
+    const service = createService(environment);
+
+    await expect((service as any).getEnvironmentsToBuild(7)).resolves.toEqual([environment]);
+  });
+
+  test('returns empty for a null environmentId instead of querying the removed services relation', async () => {
+    const service = createService(undefined);
+
+    await expect((service as any).getEnvironmentsToBuild(null)).resolves.toEqual([]);
+    expect((service as any).db.models.Environment.find).not.toHaveBeenCalled();
+  });
+
+  test('returns empty when the environment is missing rather than a list holding undefined', async () => {
+    const service = createService(undefined);
+
+    // toStrictEqual: toEqual treats [undefined] as [], which would hide the old push-undefined behaviour.
+    await expect((service as any).getEnvironmentsToBuild(99)).resolves.toStrictEqual([]);
+  });
+});
+
 describe('BuildService stale deploy reconciliation', () => {
   let buildService: BuildService;
   let deployableQuery: any;

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -2254,7 +2254,7 @@ export default class BuildService extends BaseService {
     environmentId,
     lifecycleConfig,
   }: DeployOptions & { repositoryId: number }) {
-    const environments = await this.getEnvironmentsToBuild(environmentId, repositoryId);
+    const environments = await this.getEnvironmentsToBuild(environmentId);
 
     if (!environments.length) {
       getLogger().debug('Build: no matching environments');
@@ -3648,19 +3648,15 @@ export default class BuildService extends BaseService {
   /**
    * Returns an array of environments to build.
    * @param environmentId the default environmentId (if one exists)
-   * @param repositoryId the repository to use for finding relevant environments, if needed
    */
-  private async getEnvironmentsToBuild(environmentId: number | undefined, repositoryId: number) {
-    let environments: Environment[] = [];
-    if (environmentId != null) {
-      environments.push(await this.db.models.Environment.findOne({ id: environmentId }));
-    } else {
-      environments = environments.concat(
-        await this.db.models.Environment.find().withGraphJoined('services').where('services.repositoryId', repositoryId)
-      );
+  private async getEnvironmentsToBuild(environmentId: number | undefined): Promise<Environment[]> {
+    if (environmentId == null) {
+      return [];
     }
 
-    return environments;
+    const environment = await this.db.models.Environment.findOne({ id: environmentId });
+
+    return environment != null ? [environment] : [];
   }
 
   private async updateDeploysImageDetails(


### PR DESCRIPTION
## Summary

Phase 1 of the dead-code cleanup (#228) removed `Environment.relationMappings.services` along with the rest of the legacy DB-config path, but left one call site behind in `getEnvironmentsToBuild`:

```ts
Environment.find().withGraphJoined('services').where('services.repositoryId', repositoryId)
```

Objection throws `UnknownRelationError: services` when this runs.

## Impact

Latent, not loud. The branch only executes when `environmentId` is null — i.e. a repository whose `defaultEnvId` is not set (`github.ts` passes `repository?.defaultEnvId` straight through to `createBuildAndDeploys`). Repositories onboarded normally have a `defaultEnvId`, which is why production has been quiet since #228 merged.

## Fix

That `else` branch was the DB-service-based environment lookup — *"find the environments that own a service belonging to this repo"*. Under YAML config a repository's environment **is** its `defaultEnvId`, so the branch is meaningless now and is removed rather than repaired. Returning `[]` is exactly what the caller already handles:

```ts
if (!environments.length) {
  getLogger().debug('Build: no matching environments');
  return;
}
```

Also stops pushing a possibly-`undefined` `findOne()` result into the array, which would otherwise surface later as an undefined element during `environments.map(...)`.

## Testing

- New `BuildService getEnvironmentsToBuild` suite, verified to **fail on the previous implementation** and pass on this one. The `Environment.find` mock throws if called, and the missing-environment case uses `toStrictEqual` so `[undefined]` cannot pass as `[]`.
- Full suite: **3768 passed**. `lint` clean. `ts-check`: 291 errors on `main`, 291 on this branch — zero new.

Found while re-verifying scope for phase 2 of the cleanup.
