### PR TITLE
fix: run and await after-build pipelines before deploying

### DIFF
--- a/src/server/db/migrations/033_add_after_build_completion_key.ts
+++ b/src/server/db/migrations/033_add_after_build_completion_key.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 GoodRx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn('deploys', 'afterBuildCompletionKey')) return;
+
+  await knex.schema.alterTable('deploys', (table) => {
+    table.text('afterBuildCompletionKey').nullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn('deploys', 'afterBuildCompletionKey'))) return;
+
+  await knex.schema.alterTable('deploys', (table) => {
+    table.dropColumn('afterBuildCompletionKey');
+  });
+}

--- a/src/server/models/Deploy.ts
+++ b/src/server/models/Deploy.ts
@@ -62,6 +62,7 @@ export default class Deploy extends Model {
   buildOutput: string;
   deployOutput: string;
   buildJobName: string;
+  afterBuildCompletionKey: string | null;
   manifest: string;
   devMode: boolean;
   devModeSessionId: number | null;

--- a/src/server/services/__tests__/build.test.ts
+++ b/src/server/services/__tests__/build.test.ts
@@ -1239,76 +1239,43 @@ describe('BuildService deployment reconciliation', () => {
     mockAcceptDeploymentIntent.mockResolvedValue({ accepted: true, generation: 1, scopeKey: 'all' });
   });
 
-  test.each([
-    ['a newer live PR generation', createBuild({ desiredGeneration: 8, runUUID: 'run-c', pullRequestId: 11 }), 7, true],
-    [
-      'a newer live static generation',
-      createBuild({
-        desiredGeneration: 8,
-        runUUID: 'run-c',
-        pullRequest: null,
-        pullRequestId: null,
-        deployEnabled: true,
-        isStatic: true,
-      }),
-      7,
-      true,
-    ],
-    ['the same generation', createBuild({ desiredGeneration: 7, runUUID: 'other-run' }), 7, false],
-    [
-      'a closed PR',
-      createBuild({
-        desiredGeneration: 8,
-        runUUID: 'run-c',
-        pullRequestId: 11,
-        pullRequest: { status: 'closed', deployOnUpdate: true },
-      }),
-      7,
-      false,
-    ],
-    [
-      'a deploy-disabled PR',
-      createBuild({
-        desiredGeneration: 8,
-        runUUID: 'run-c',
-        pullRequestId: 11,
-        pullRequest: { status: 'open', deployOnUpdate: false },
-      }),
-      7,
-      false,
-    ],
-    [
-      'an API teardown',
-      createBuild({
-        desiredGeneration: 8,
-        runUUID: 'build-teardown-1',
-        status: BuildStatus.TEARING_DOWN,
-        pullRequest: null,
-        pullRequestId: null,
-        deployEnabled: false,
-      }),
-      7,
-      false,
-    ],
-    [
-      'a PR teardown owner before status publication',
-      createBuild({
-        desiredGeneration: 8,
-        runUUID: 'build-teardown-1',
-        pullRequestId: 11,
-      }),
-      7,
-      false,
-    ],
-    ['a deleted Build', createBuild({ desiredGeneration: 8, deletedAt: '2026-08-06T00:00:00Z' }), 7, false],
-    ['a stale run without a generation', createBuild({ desiredGeneration: 8 }), undefined, false],
-  ])('permits stale after-build only for %s', async (_case, build, expectedGeneration, expected) => {
+  const deploymentScopeHarness = (buildImagesResult: boolean) => {
     const { service } = serviceHarness();
-    jest.spyOn(service as any, 'loadBuildDeploymentAuthority').mockResolvedValue(build);
+    const build = createBuild({ id: 1, runUUID: 'run-current', namespace: 'env-sample' });
+    jest.spyOn(service as any, 'isDeploymentRunCurrent').mockResolvedValue(true);
+    const buildImages = jest.spyOn(service as any, 'buildImages').mockResolvedValue(buildImagesResult);
+    jest.spyOn(service as any, 'deployCLIServices').mockResolvedValue(true);
+    const updateStatus = jest.spyOn(service as any, 'updateStatusAndComment').mockResolvedValue(undefined);
+    const applyManifests = jest.spyOn(service as any, 'generateAndApplyManifests').mockResolvedValue(true);
+    const preparation = {
+      build,
+      runUUID: 'run-current',
+      githubRepositoryId: 100,
+      sourceGithubRepositoryId: 100,
+      sourceRef: 'commit-a',
+      sourceBranch: 'main',
+    };
+    return { service, preparation, buildImages, updateStatus, applyManifests };
+  };
 
-    await expect(
-      service.isSupersededByNewerLiveDeploymentGeneration(1, expectedGeneration as number | undefined)
-    ).resolves.toBe(expected);
+  test('a failed image phase reports ERROR and never reaches manifest apply', async () => {
+    const { service, preparation, buildImages, updateStatus, applyManifests } = deploymentScopeHarness(false);
+
+    const result = await (service as any).executeDeploymentScope(preparation, 7);
+
+    expect(result).toEqual({ status: BuildStatus.ERROR });
+    expect(buildImages).toHaveBeenCalledTimes(1);
+    expect(updateStatus).not.toHaveBeenCalled();
+    expect(applyManifests).not.toHaveBeenCalled();
+  });
+
+  test('a successful image phase proceeds to manifest apply and reports DEPLOYED', async () => {
+    const { service, preparation, applyManifests } = deploymentScopeHarness(true);
+
+    const result = await (service as any).executeDeploymentScope(preparation, 7);
+
+    expect(result).toEqual({ status: BuildStatus.DEPLOYED });
+    expect(applyManifests).toHaveBeenCalledTimes(1);
   });
 
   test('signals only the exact durable generation accepted by the mailbox', async () => {

--- a/src/server/services/__tests__/deploy.test.ts
+++ b/src/server/services/__tests__/deploy.test.ts
@@ -928,6 +928,20 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
         })
       );
       expect(mockCodefreshWaitForImage).toHaveBeenCalledWith('after-build-run');
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        status: DeployStatus.BUILDING,
+        statusMessage: 'Running after-build pipeline...',
+        buildLogs: null,
+      });
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        buildLogs: 'https://g.codefresh.io/build/after-build-run',
+      });
+      const runningPatchIndex = conditionalDeployPatch.mock.calls.findIndex(
+        ([params]) => params.buildLogs === 'https://g.codefresh.io/build/after-build-run'
+      );
+      expect(conditionalDeployPatch.mock.invocationCallOrder[runningPatchIndex]).toBeLessThan(
+        mockCodefreshWaitForImage.mock.invocationCallOrder[0]
+      );
       expect(mockGetLogger).toHaveBeenCalledWith(
         expect.objectContaining({
           afterBuildPipelineId: 'sample/after-build',
@@ -965,7 +979,7 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       expect(mockCodefreshWaitForImage).not.toHaveBeenCalled();
       expect(patchTagSpy).not.toHaveBeenCalled();
       expect(conditionalDeployPatch).toHaveBeenCalledTimes(1);
-      expect(conditionalDeployPatch).toHaveBeenCalledWith({ afterBuildCompletionKey: null });
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({ afterBuildCompletionKey: null, buildLogs: null });
       expect(mockLoggerInfo).toHaveBeenCalledWith(
         'Image: native result publication skipped reason=superseded result=success'
       );
@@ -976,6 +990,7 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       const deploy = createNativeAfterBuildDeploy();
       const patchTagSpy = prepareNativeAfterBuildTest(() => current);
       mockBuildWithNative.mockResolvedValue({ success: true });
+      conditionalDeployPatch.mockImplementation(async () => (current ? 1 : 0));
       mockCodefreshTriggerPipeline.mockImplementation(async () => {
         current = false;
         return 'after-build-run';
@@ -994,6 +1009,12 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       expect(mockCodefreshTriggerPipeline).toHaveBeenCalledTimes(1);
       expect(mockCodefreshWaitForImage).toHaveBeenCalledWith('after-build-run');
       expect(patchTagSpy).not.toHaveBeenCalled();
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        buildLogs: 'https://g.codefresh.io/build/after-build-run',
+      });
+      expect(
+        conditionalDeployWhere.mock.calls.every(([where]) => where.id === deploy.id && where.runUUID === 'run-a')
+      ).toBe(true);
     });
 
     test('a failed superseded native build neither invokes the after-build pipeline nor publishes failure', async () => {
@@ -1044,9 +1065,15 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       expect(patchTagSpy).not.toHaveBeenCalled();
       expect(deployService.patchAndUpdateActivityFeed).toHaveBeenCalledWith(
         deploy,
-        { status: DeployStatus.BUILD_FAILED },
+        {
+          status: DeployStatus.BUILD_FAILED,
+          statusMessage: 'After-build pipeline failed.',
+        },
         'run-1'
       );
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        buildLogs: 'https://g.codefresh.io/build/after-build-run',
+      });
       expect(mockCodefreshTriggerPipeline).toHaveBeenCalledTimes(1);
       expect(mockCodefreshWaitForImage).toHaveBeenCalledWith('after-build-run');
       expect(mockGetLogger).toHaveBeenCalledWith(
@@ -1060,6 +1087,40 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
           /^Codefresh: after-build pipeline completed result=failure afterBuildPipelineId=sample\/after-build pipelineId=after-build-run imageTag=/
         )
       );
+    });
+
+    test('a current after-build trigger error publishes a terminal after-build failure', async () => {
+      const deploy = createNativeAfterBuildDeploy();
+      const patchTagSpy = prepareNativeAfterBuildTest(() => true);
+      mockBuildWithNative.mockResolvedValue({ success: true });
+      mockCodefreshTriggerPipeline.mockRejectedValue(new Error('Codefresh unavailable'));
+
+      const result = await deployService.buildImageForHelmAndGithub(
+        deploy as any,
+        'run-1',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+
+      expect(result).toBe(false);
+      expect(mockCodefreshWaitForImage).not.toHaveBeenCalled();
+      expect(patchTagSpy).not.toHaveBeenCalled();
+      expect(deployService.patchAndUpdateActivityFeed).toHaveBeenCalledWith(
+        deploy,
+        { status: DeployStatus.BUILD_FAILED, statusMessage: 'After-build pipeline failed.' },
+        'run-1'
+      );
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        status: DeployStatus.BUILDING,
+        statusMessage: 'Running after-build pipeline...',
+        buildLogs: null,
+      });
+      expect(conditionalDeployPatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ buildLogs: expect.stringContaining('g.codefresh.io/build/') })
+      );
+      expect(mockLoggerWarn).toHaveBeenCalledWith('Codefresh: after-build pipeline trigger failed');
     });
 
     const flushUntil = async (done: () => boolean) => {
@@ -1089,6 +1150,20 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       await flushUntil(() => mockCodefreshWaitForImage.mock.calls.length > 0);
 
       expect(mockBuildWithNative).not.toHaveBeenCalled();
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        status: DeployStatus.BUILDING,
+        statusMessage: 'Running after-build pipeline...',
+        buildLogs: null,
+      });
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        buildLogs: 'https://g.codefresh.io/build/after-build-run',
+      });
+      const afterBuildUrlPatchIndex = conditionalDeployPatch.mock.calls.findIndex(
+        ([params]) => params.buildLogs === 'https://g.codefresh.io/build/after-build-run'
+      );
+      expect(conditionalDeployPatch.mock.invocationCallOrder[afterBuildUrlPatchIndex]).toBeLessThan(
+        mockCodefreshWaitForImage.mock.invocationCallOrder[0]
+      );
       expect(mockCodefreshTriggerPipeline).toHaveBeenCalledTimes(1);
       expect(mockCodefreshTriggerPipeline).toHaveBeenCalledWith(
         'sample/after-build',
@@ -1132,9 +1207,10 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       expect(mockCodefreshTriggerPipeline).not.toHaveBeenCalled();
       expect(mockCodefreshWaitForImage).not.toHaveBeenCalled();
       expect(patchTagSpy).toHaveBeenCalledTimes(1);
+      expect(conditionalDeployPatch).not.toHaveBeenCalledWith(expect.objectContaining({ buildLogs: null }));
     });
 
-    test('rebuilding an image clears a previously recorded completion', async () => {
+    test('rebuilding an image clears the previous completion and build link before building', async () => {
       const deploy = createNativeAfterBuildDeploy() as any;
       deploy.afterBuildCompletionKey = 'sample/after-build@stale-tag';
       const patchTagSpy = prepareNativeAfterBuildTest(() => true);
@@ -1150,7 +1226,13 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       );
 
       expect(result).toBe(true);
-      expect(conditionalDeployPatch).toHaveBeenCalledWith({ afterBuildCompletionKey: null });
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({ afterBuildCompletionKey: null, buildLogs: null });
+      const rebuildClearIndex = conditionalDeployPatch.mock.calls.findIndex(
+        ([params]) => params.afterBuildCompletionKey === null && params.buildLogs === null
+      );
+      expect(conditionalDeployPatch.mock.invocationCallOrder[rebuildClearIndex]).toBeLessThan(
+        mockBuildWithNative.mock.invocationCallOrder[0]
+      );
       expect(patchTagSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -1244,9 +1326,15 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       expect(patchTagSpy).not.toHaveBeenCalled();
       expect(deployService.patchAndUpdateActivityFeed).toHaveBeenCalledWith(
         deploy,
-        { status: DeployStatus.BUILD_FAILED },
+        {
+          status: DeployStatus.BUILD_FAILED,
+          statusMessage: 'After-build pipeline failed.',
+        },
         'run-b'
       );
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        buildLogs: 'https://g.codefresh.io/build/after-build-run',
+      });
     });
 
     test('a codefresh-engine cache hit still runs and awaits the after-build pipeline before BUILT', async () => {

--- a/src/server/services/__tests__/deploy.test.ts
+++ b/src/server/services/__tests__/deploy.test.ts
@@ -15,6 +15,7 @@
  */
 
 import mockRedisClient from 'server/lib/__mocks__/redisClientMock';
+import hash from 'object-hash';
 import DeployService from '../deploy';
 import { DeployStatus, DeployTypes } from 'shared/constants';
 import { ChartType } from 'server/lib/nativeHelm';
@@ -35,7 +36,6 @@ const mockBuildWithNative = jest.fn();
 const mockGlobalConfigGetAllConfigs = jest.fn();
 const mockGlobalConfigGetOrgChartName = jest.fn();
 const mockCreateOrUpdateNamespace = jest.fn();
-const mockIsSupersededByNewerLiveDeploymentGeneration = jest.fn();
 const mockLoggerInfo = jest.fn();
 const mockLoggerWarn = jest.fn();
 const mockGetLogger = jest.fn(() => ({
@@ -136,8 +136,6 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
     mockCodefreshWaitForImage.mockReset();
     mockBuildWithNative.mockReset();
     mockCreateOrUpdateNamespace.mockReset();
-    mockIsSupersededByNewerLiveDeploymentGeneration.mockReset();
-    mockIsSupersededByNewerLiveDeploymentGeneration.mockResolvedValue(false);
     mockGlobalConfigGetOrgChartName.mockResolvedValue('org-chart');
     mockGlobalConfigGetAllConfigs.mockResolvedValue({
       lifecycleDefaults: {
@@ -163,12 +161,7 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
           query: jest.fn(() => ({ where: conditionalDeployWhere, findOne: currentDeployFindOne })),
         },
       },
-      services: {
-        BuildService: {
-          isSupersededByNewerLiveDeploymentGeneration: (...args: any[]) =>
-            mockIsSupersededByNewerLiveDeploymentGeneration(...args),
-        },
-      },
+      services: {},
     };
 
     mockRedis = {};
@@ -949,45 +942,7 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       );
     });
 
-    test('a superseded native build still invokes its after-build pipeline without publishing stale image state', async () => {
-      let current = true;
-      const deploy = createNativeAfterBuildDeploy();
-      const patchTagSpy = prepareNativeAfterBuildTest(() => current);
-      mockIsSupersededByNewerLiveDeploymentGeneration.mockResolvedValue(true);
-      mockBuildWithNative.mockImplementation(async () => {
-        current = false;
-        return { success: true, logs: 'native build completed' };
-      });
-
-      const result = await deployService.buildImageForHelmAndGithub(
-        deploy as any,
-        'run-a',
-        undefined,
-        undefined,
-        undefined,
-        7
-      );
-
-      expect(result).toBe(true);
-      expect(mockCodefreshTriggerPipeline).toHaveBeenCalledTimes(1);
-      expect(mockIsSupersededByNewerLiveDeploymentGeneration).toHaveBeenCalledWith(91, 7);
-      expect(mockCodefreshWaitForImage).not.toHaveBeenCalled();
-      expect(patchTagSpy).not.toHaveBeenCalled();
-      expect(conditionalDeployPatch).not.toHaveBeenCalled();
-      expect(mockGetLogger).toHaveBeenCalledWith(
-        expect.objectContaining({
-          afterBuildPipelineId: 'sample/after-build',
-          pipelineId: 'after-build-run',
-        })
-      );
-      expect(mockLoggerInfo).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /^Codefresh: after-build pipeline detached reason=superseded afterBuildPipelineId=sample\/after-build pipelineId=after-build-run imageTag=/
-        )
-      );
-    });
-
-    test('a native build superseded by teardown does not invoke its after-build pipeline', async () => {
+    test('a superseded native build publishes nothing and does not trigger its after-build pipeline', async () => {
       let current = true;
       const deploy = createNativeAfterBuildDeploy();
       const patchTagSpy = prepareNativeAfterBuildTest(() => current);
@@ -1006,44 +961,17 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       );
 
       expect(result).toBe(true);
-      expect(mockIsSupersededByNewerLiveDeploymentGeneration).toHaveBeenCalledWith(91, 7);
       expect(mockCodefreshTriggerPipeline).not.toHaveBeenCalled();
       expect(mockCodefreshWaitForImage).not.toHaveBeenCalled();
       expect(patchTagSpy).not.toHaveBeenCalled();
-      expect(conditionalDeployPatch).not.toHaveBeenCalled();
+      expect(conditionalDeployPatch).toHaveBeenCalledTimes(1);
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({ afterBuildCompletionKey: null });
       expect(mockLoggerInfo).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /^Codefresh: after-build pipeline skipped reason=no_live_successor afterBuildPipelineId=sample\/after-build imageTag=/
-        )
+        'Image: native result publication skipped reason=superseded result=success'
       );
     });
 
-    test('a stale native build fails closed when live-successor authority cannot be read', async () => {
-      let current = true;
-      const deploy = createNativeAfterBuildDeploy();
-      prepareNativeAfterBuildTest(() => current);
-      mockIsSupersededByNewerLiveDeploymentGeneration.mockRejectedValue(new Error('database unavailable'));
-      mockBuildWithNative.mockImplementation(async () => {
-        current = false;
-        return { success: true };
-      });
-
-      const result = await deployService.buildImageForHelmAndGithub(
-        deploy as any,
-        'run-a',
-        undefined,
-        undefined,
-        undefined,
-        7
-      );
-
-      expect(result).toBe(true);
-      expect(mockCodefreshTriggerPipeline).not.toHaveBeenCalled();
-      expect(mockCodefreshWaitForImage).not.toHaveBeenCalled();
-      expect(mockLoggerWarn).toHaveBeenCalledWith('Codefresh: after-build successor check failed');
-    });
-
-    test('a native after-build pipeline is left detached when superseded during its trigger', async () => {
+    test('a run superseded during its after-build trigger still awaits the pipeline result', async () => {
       let current = true;
       const deploy = createNativeAfterBuildDeploy();
       const patchTagSpy = prepareNativeAfterBuildTest(() => current);
@@ -1063,9 +991,9 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       );
 
       expect(result).toBe(true);
-      expect(patchTagSpy).toHaveBeenCalledTimes(1);
       expect(mockCodefreshTriggerPipeline).toHaveBeenCalledTimes(1);
-      expect(mockCodefreshWaitForImage).not.toHaveBeenCalled();
+      expect(mockCodefreshWaitForImage).toHaveBeenCalledWith('after-build-run');
+      expect(patchTagSpy).not.toHaveBeenCalled();
     });
 
     test('a failed superseded native build neither invokes the after-build pipeline nor publishes failure', async () => {
@@ -1113,7 +1041,12 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
       );
 
       expect(result).toBe(false);
-      expect(patchTagSpy).toHaveBeenCalledTimes(1);
+      expect(patchTagSpy).not.toHaveBeenCalled();
+      expect(deployService.patchAndUpdateActivityFeed).toHaveBeenCalledWith(
+        deploy,
+        { status: DeployStatus.BUILD_FAILED },
+        'run-1'
+      );
       expect(mockCodefreshTriggerPipeline).toHaveBeenCalledTimes(1);
       expect(mockCodefreshWaitForImage).toHaveBeenCalledWith('after-build-run');
       expect(mockGetLogger).toHaveBeenCalledWith(
@@ -1126,6 +1059,277 @@ describe('DeployService - shouldTriggerGithubDeployment', () => {
         expect.stringMatching(
           /^Codefresh: after-build pipeline completed result=failure afterBuildPipelineId=sample\/after-build pipelineId=after-build-run imageTag=/
         )
+      );
+    });
+
+    const flushUntil = async (done: () => boolean) => {
+      for (let i = 0; i < 20 && !done(); i++) await new Promise((resolve) => setImmediate(resolve));
+    };
+
+    test('a run that finds the image already pushed still runs and awaits the after-build pipeline before BUILT', async () => {
+      const deploy = createNativeAfterBuildDeploy();
+      const patchTagSpy = prepareNativeAfterBuildTest(() => true);
+      mockCodefreshTagExists.mockResolvedValue(true);
+      const pipelineResult: { resolve?: (completed: boolean) => void } = {};
+      mockCodefreshWaitForImage.mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            pipelineResult.resolve = resolve;
+          })
+      );
+
+      const resultPromise = deployService.buildImageForHelmAndGithub(
+        deploy as any,
+        'run-b',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+      await flushUntil(() => mockCodefreshWaitForImage.mock.calls.length > 0);
+
+      expect(mockBuildWithNative).not.toHaveBeenCalled();
+      expect(mockCodefreshTriggerPipeline).toHaveBeenCalledTimes(1);
+      expect(mockCodefreshTriggerPipeline).toHaveBeenCalledWith(
+        'sample/after-build',
+        'cli',
+        expect.objectContaining({
+          FEATURE_FLAG: 'enabled',
+          TAG: expect.stringContaining('/sample/app-images:lfc-abcdef1-'),
+          branch: 'feature-branch',
+        })
+      );
+      expect(mockCodefreshWaitForImage).toHaveBeenCalledWith('after-build-run');
+      expect(patchTagSpy).not.toHaveBeenCalled();
+
+      pipelineResult.resolve!(true);
+      await expect(resultPromise).resolves.toBe(true);
+      expect(patchTagSpy).toHaveBeenCalledTimes(1);
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        afterBuildCompletionKey: expect.stringMatching(
+          /^sample\/after-build@.*\/sample\/app-images:lfc-abcdef1-[^@]+$/
+        ),
+      });
+    });
+
+    test('a matching completion record skips the after-build on the existing-image path', async () => {
+      const deploy = createNativeAfterBuildDeploy() as any;
+      const patchTagSpy = prepareNativeAfterBuildTest(() => true);
+      mockCodefreshTagExists.mockResolvedValue(true);
+      const envVarsHash = hash({ FEATURE_FLAG: 'enabled' });
+      deploy.afterBuildCompletionKey = `sample/after-build@123456789012.dkr.ecr.us-west-2.amazonaws.com/sample/app-images:lfc-abcdef1-${envVarsHash}`;
+
+      const result = await deployService.buildImageForHelmAndGithub(
+        deploy,
+        'run-b',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+
+      expect(result).toBe(true);
+      expect(mockCodefreshTriggerPipeline).not.toHaveBeenCalled();
+      expect(mockCodefreshWaitForImage).not.toHaveBeenCalled();
+      expect(patchTagSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('rebuilding an image clears a previously recorded completion', async () => {
+      const deploy = createNativeAfterBuildDeploy() as any;
+      deploy.afterBuildCompletionKey = 'sample/after-build@stale-tag';
+      const patchTagSpy = prepareNativeAfterBuildTest(() => true);
+      mockBuildWithNative.mockResolvedValue({ success: true });
+
+      const result = await deployService.buildImageForHelmAndGithub(
+        deploy,
+        'run-1',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+
+      expect(result).toBe(true);
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({ afterBuildCompletionKey: null });
+      expect(patchTagSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('a rebuild that cannot clear the completion record does not build', async () => {
+      const deploy = createNativeAfterBuildDeploy() as any;
+      deploy.afterBuildCompletionKey = 'sample/after-build@stale-tag';
+      prepareNativeAfterBuildTest(() => true);
+      conditionalDeployPatch.mockResolvedValueOnce(0);
+
+      const result = await deployService.buildImageForHelmAndGithub(
+        deploy,
+        'run-1',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+
+      expect(result).toBe(true);
+      expect(mockBuildWithNative).not.toHaveBeenCalled();
+      expect(mockCodefreshBuildImage).not.toHaveBeenCalled();
+      expect(mockCodefreshTriggerPipeline).not.toHaveBeenCalled();
+    });
+
+    test('a codefresh-engine cold build records completion when its embedded after-build is not detached', async () => {
+      const deploy = createNativeAfterBuildDeploy() as any;
+      deploy.deployable.builder = { engine: 'ci' };
+      const patchTagSpy = prepareNativeAfterBuildTest(() => true);
+      mockCodefreshBuildImage.mockResolvedValue('codefresh-build-123');
+      mockCodefreshGetLogs.mockResolvedValue('codefresh logs');
+
+      const result = await deployService.buildImageForHelmAndGithub(
+        deploy,
+        'run-1',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+
+      expect(result).toBe(true);
+      expect(mockBuildWithNative).not.toHaveBeenCalled();
+      expect(conditionalDeployPatch).toHaveBeenCalledWith({
+        afterBuildCompletionKey: expect.stringMatching(
+          /^sample\/after-build@.*\/sample\/app-images:lfc-abcdef1-[^@]+$/
+        ),
+      });
+      expect(patchTagSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('a detached codefresh-engine cold build does not record completion', async () => {
+      const deploy = createNativeAfterBuildDeploy() as any;
+      deploy.deployable.builder = { engine: 'ci' };
+      deploy.deployable.detatchAfterBuildPipeline = true;
+      const patchTagSpy = prepareNativeAfterBuildTest(() => true);
+      mockCodefreshBuildImage.mockResolvedValue('codefresh-build-123');
+      mockCodefreshGetLogs.mockResolvedValue('codefresh logs');
+
+      const result = await deployService.buildImageForHelmAndGithub(
+        deploy,
+        'run-1',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+
+      expect(result).toBe(true);
+      expect(conditionalDeployPatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ afterBuildCompletionKey: expect.any(String) })
+      );
+      expect(patchTagSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('a failed after-build on the existing-image path never publishes BUILT', async () => {
+      const deploy = createNativeAfterBuildDeploy();
+      const patchTagSpy = prepareNativeAfterBuildTest(() => true);
+      mockCodefreshTagExists.mockResolvedValue(true);
+      mockCodefreshWaitForImage.mockResolvedValue(false);
+
+      const result = await deployService.buildImageForHelmAndGithub(
+        deploy as any,
+        'run-b',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+
+      expect(result).toBe(false);
+      expect(patchTagSpy).not.toHaveBeenCalled();
+      expect(deployService.patchAndUpdateActivityFeed).toHaveBeenCalledWith(
+        deploy,
+        { status: DeployStatus.BUILD_FAILED },
+        'run-b'
+      );
+    });
+
+    test('a codefresh-engine cache hit still runs and awaits the after-build pipeline before BUILT', async () => {
+      const deploy = createNativeAfterBuildDeploy() as any;
+      deploy.deployable.builder = { engine: 'ci' };
+      const patchTagSpy = prepareNativeAfterBuildTest(() => true);
+      mockCodefreshTagExists.mockResolvedValue(true);
+      const pipelineResult: { resolve?: (completed: boolean) => void } = {};
+      mockCodefreshWaitForImage.mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            pipelineResult.resolve = resolve;
+          })
+      );
+
+      const resultPromise = deployService.buildImageForHelmAndGithub(
+        deploy,
+        'run-b',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+      await flushUntil(() => mockCodefreshWaitForImage.mock.calls.length > 0);
+
+      expect(mockBuildWithNative).not.toHaveBeenCalled();
+      expect(mockCodefreshBuildImage).not.toHaveBeenCalled();
+      expect(mockCodefreshTriggerPipeline).toHaveBeenCalledWith(
+        'sample/after-build',
+        'cli',
+        expect.objectContaining({
+          TAG: expect.stringContaining('/sample/app-images:lfc-abcdef1-'),
+          SOURCE_REVISION: 'abcdef1234567890',
+          SOURCE_BRANCH: 'feature-branch',
+        })
+      );
+      expect(patchTagSpy).not.toHaveBeenCalled();
+
+      pipelineResult.resolve!(true);
+      await expect(resultPromise).resolves.toBe(true);
+      expect(patchTagSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('a run superseded during the existing-image after-build wait publishes neither BUILT nor BUILD_FAILED', async () => {
+      let current = true;
+      const deploy = createNativeAfterBuildDeploy();
+      const patchTagSpy = prepareNativeAfterBuildTest(() => current);
+      mockCodefreshTagExists.mockResolvedValue(true);
+      const pipelineResult: { resolve?: (completed: boolean) => void } = {};
+      mockCodefreshWaitForImage.mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            pipelineResult.resolve = resolve;
+          })
+      );
+
+      const resultPromise = deployService.buildImageForHelmAndGithub(
+        deploy as any,
+        'run-b',
+        undefined,
+        undefined,
+        undefined,
+        7
+      );
+      await flushUntil(() => mockCodefreshWaitForImage.mock.calls.length > 0);
+
+      current = false;
+      pipelineResult.resolve!(true);
+
+      await expect(resultPromise).resolves.toBe(true);
+      expect(patchTagSpy).not.toHaveBeenCalled();
+      expect(deployService.patchAndUpdateActivityFeed).not.toHaveBeenCalledWith(
+        deploy,
+        { status: DeployStatus.BUILT },
+        'run-b'
+      );
+      expect(deployService.patchAndUpdateActivityFeed).not.toHaveBeenCalledWith(
+        deploy,
+        { status: DeployStatus.BUILD_FAILED },
+        'run-b'
+      );
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'Image: after-build publication skipped reason=superseded result=success'
       );
     });
 

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -2616,26 +2616,6 @@ export default class BuildService extends BaseService {
     return build ?? null;
   }
 
-  /**
-   * Prove that stale work lost authority to a newer live deployment intent,
-   * rather than teardown, deletion, or another non-deployment owner.
-   */
-  async isSupersededByNewerLiveDeploymentGeneration(buildId: number, expectedGeneration?: number): Promise<boolean> {
-    if (expectedGeneration == null || !Number.isSafeInteger(expectedGeneration)) return false;
-
-    const current = await this.loadBuildDeploymentAuthority(buildId);
-    const desiredGeneration = Number(current?.desiredGeneration);
-    return Boolean(
-      current &&
-        Number.isSafeInteger(desiredGeneration) &&
-        desiredGeneration > expectedGeneration &&
-        current.status !== BuildStatus.TEARING_DOWN &&
-        current.status !== BuildStatus.TORN_DOWN &&
-        current.runUUID !== buildTeardownRunUUID(buildId) &&
-        this.deploymentBlockReason(current) == null
-    );
-  }
-
   private async isBuildSetupRunCurrent(buildId: number, runUUID: string): Promise<boolean> {
     const current = await this.loadBuildDeploymentAuthority(buildId);
     return Boolean(current && current.runUUID === runUUID && this.buildSetupBlockReason(current) == null);

--- a/src/server/services/deploy.ts
+++ b/src/server/services/deploy.ts
@@ -67,6 +67,9 @@ interface SyncedServiceExternalSecrets {
   buildSecretEnvKeys: Set<string>;
 }
 
+const AFTER_BUILD_RUNNING_MESSAGE = 'Running after-build pipeline...';
+const AFTER_BUILD_FAILED_MESSAGE = 'After-build pipeline failed.';
+
 export default class DeployService extends BaseService {
   /**
    * Creates all of the relevant deploys for a build, based on the provided environment, if they do not already exist.
@@ -871,18 +874,36 @@ export default class DeployService extends BaseService {
     branchName: string;
     sourceRevision: string;
   }): Promise<boolean> {
-    // Superset of the native (branch) and Codefresh-embedded (SOURCE_*) invocation contracts.
-    const pipelineId = await codefresh.triggerPipeline(afterBuildPipelineId, 'cli', {
-      ...deploy.env,
-      TAG: ecrRepoTag,
-      branch: branchName,
-      SOURCE_REVISION: sourceRevision,
-      SOURCE_BRANCH: branchName,
+    const current = await this.patchDeployForRun(deploy, runUUID, {
+      status: DeployStatus.BUILDING,
+      statusMessage: AFTER_BUILD_RUNNING_MESSAGE,
+      buildLogs: null,
     });
+    if (!current) return false;
+
+    let pipelineId: string;
+    try {
+      // Superset of the native (branch) and Codefresh-embedded (SOURCE_*) invocation contracts.
+      pipelineId = await codefresh.triggerPipeline(afterBuildPipelineId, 'cli', {
+        ...deploy.env,
+        TAG: ecrRepoTag,
+        branch: branchName,
+        SOURCE_REVISION: sourceRevision,
+        SOURCE_BRANCH: branchName,
+      });
+    } catch (error) {
+      getLogger({ error, afterBuildPipelineId, imageTag: ecrRepoTag }).warn(
+        'Codefresh: after-build pipeline trigger failed'
+      );
+      return false;
+    }
     const details = `afterBuildPipelineId=${afterBuildPipelineId} pipelineId=${pipelineId} imageTag=${ecrRepoTag}`;
     const logger = getLogger({ afterBuildPipelineId, pipelineId, imageTag: ecrRepoTag });
     logger.info(`Codefresh: after-build pipeline triggered ${details}`);
 
+    await this.patchDeployForRun(deploy, runUUID, {
+      buildLogs: `https://g.codefresh.io/build/${pipelineId}`,
+    });
     const completed = await codefresh.waitForImage(pipelineId);
     if (!completed) {
       logger.warn(`Codefresh: after-build pipeline completed result=failure ${details}`);
@@ -1132,13 +1153,13 @@ export default class DeployService extends BaseService {
         }
 
         await deploy.reload();
-        // A prior build's completion must not vouch for the new image; the clear fails closed.
-        if (deployable.afterBuildPipelineId) {
-          const cleared = await this.patchDeployForRun(deploy, runUUID, { afterBuildCompletionKey: null });
-          if (!cleared) {
-            getLogger().info('Image: stopped before build reason=superseded');
-            return true;
-          }
+        const prepared = await this.patchDeployForRun(deploy, runUUID, {
+          buildLogs: null,
+          ...(deployable.afterBuildPipelineId ? { afterBuildCompletionKey: null } : {}),
+        });
+        if (!prepared) {
+          getLogger().info('Image: stopped before build reason=superseded');
+          return true;
         }
         await this.patchAndUpdateActivityFeed(
           deploy,
@@ -1257,7 +1278,11 @@ export default class DeployService extends BaseService {
                 return true;
               }
               if (!completed) {
-                await this.patchAndUpdateActivityFeed(deploy, { status: DeployStatus.BUILD_FAILED }, runUUID);
+                await this.patchAndUpdateActivityFeed(
+                  deploy,
+                  { status: DeployStatus.BUILD_FAILED, statusMessage: AFTER_BUILD_FAILED_MESSAGE },
+                  runUUID
+                );
                 return false;
               }
             }
@@ -1343,7 +1368,11 @@ export default class DeployService extends BaseService {
               return true;
             }
             if (!completed) {
-              await this.patchAndUpdateActivityFeed(deploy, { status: DeployStatus.BUILD_FAILED }, runUUID);
+              await this.patchAndUpdateActivityFeed(
+                deploy,
+                { status: DeployStatus.BUILD_FAILED, statusMessage: AFTER_BUILD_FAILED_MESSAGE },
+                runUUID
+              );
               return false;
             }
           }

--- a/src/server/services/deploy.ts
+++ b/src/server/services/deploy.ts
@@ -851,6 +851,50 @@ export default class DeployService extends BaseService {
     });
   }
 
+  // A Lifecycle tag (sha + env hash) identifies equivalent build outputs, so it keys the completion.
+  private afterBuildCompletionKeyFor(afterBuildPipelineId: string, ecrRepoTag: string): string {
+    return `${afterBuildPipelineId}@${ecrRepoTag}`;
+  }
+
+  private async runAfterBuildPipeline({
+    deploy,
+    runUUID,
+    afterBuildPipelineId,
+    ecrRepoTag,
+    branchName,
+    sourceRevision,
+  }: {
+    deploy: Deploy;
+    runUUID: string;
+    afterBuildPipelineId: string;
+    ecrRepoTag: string;
+    branchName: string;
+    sourceRevision: string;
+  }): Promise<boolean> {
+    // Superset of the native (branch) and Codefresh-embedded (SOURCE_*) invocation contracts.
+    const pipelineId = await codefresh.triggerPipeline(afterBuildPipelineId, 'cli', {
+      ...deploy.env,
+      TAG: ecrRepoTag,
+      branch: branchName,
+      SOURCE_REVISION: sourceRevision,
+      SOURCE_BRANCH: branchName,
+    });
+    const details = `afterBuildPipelineId=${afterBuildPipelineId} pipelineId=${pipelineId} imageTag=${ecrRepoTag}`;
+    const logger = getLogger({ afterBuildPipelineId, pipelineId, imageTag: ecrRepoTag });
+    logger.info(`Codefresh: after-build pipeline triggered ${details}`);
+
+    const completed = await codefresh.waitForImage(pipelineId);
+    if (!completed) {
+      logger.warn(`Codefresh: after-build pipeline completed result=failure ${details}`);
+      return false;
+    }
+    await this.patchDeployForRun(deploy, runUUID, {
+      afterBuildCompletionKey: this.afterBuildCompletionKeyFor(afterBuildPipelineId, ecrRepoTag),
+    });
+    logger.info(`Codefresh: after-build pipeline completed result=success ${details}`);
+    return true;
+  }
+
   private async syncServiceExternalSecrets({
     deploy,
     serviceName,
@@ -1088,6 +1132,14 @@ export default class DeployService extends BaseService {
         }
 
         await deploy.reload();
+        // A prior build's completion must not vouch for the new image; the clear fails closed.
+        if (deployable.afterBuildPipelineId) {
+          const cleared = await this.patchDeployForRun(deploy, runUUID, { afterBuildCompletionKey: null });
+          if (!cleared) {
+            getLogger().info('Image: stopped before build reason=superseded');
+            return true;
+          }
+        }
         await this.patchAndUpdateActivityFeed(
           deploy,
           { status: DeployStatus.BUILDING, sha: fullSha, statusMessage: `Building ${deploy?.uuid}...` },
@@ -1186,72 +1238,31 @@ export default class DeployService extends BaseService {
           }
 
           if (result.success) {
-            if (runIsCurrent) {
-              await this.patchDeployWithTag({ tag, initTag, deploy, ecrDomain, runUUID });
-              runIsCurrent = await this.isDeploymentRunCurrent(deploy, runUUID, expectedGeneration);
-            }
+            // The successor re-runs any missing after-build on its image-exists path.
+            if (!runIsCurrent) return true;
 
             if (buildOptions?.afterBuildPipelineId) {
-              // This pipeline belongs to the produced image. A newer live generation may detach it,
-              // while teardown or deletion must suppress new external work.
-              const ecrRepoTag = constructEcrTag({ repo: ecrRepo, tag, ecrDomain });
-
-              if (!runIsCurrent) {
-                let hasLiveSuccessor = false;
-                try {
-                  hasLiveSuccessor = await this.db.services.BuildService.isSupersededByNewerLiveDeploymentGeneration(
-                    deploy.buildId,
-                    expectedGeneration
-                  );
-                } catch (error) {
-                  getLogger({ error }).warn('Codefresh: after-build successor check failed');
-                }
-
-                if (!hasLiveSuccessor) {
-                  const skippedLog = {
-                    afterBuildPipelineId: buildOptions.afterBuildPipelineId,
-                    imageTag: ecrRepoTag,
-                  };
-                  getLogger(skippedLog).info(
-                    `Codefresh: after-build pipeline skipped reason=no_live_successor ` +
-                      `afterBuildPipelineId=${skippedLog.afterBuildPipelineId} imageTag=${skippedLog.imageTag}`
-                  );
-                  return true;
-                }
-              }
-
-              const afterbuildPipeline = await codefresh.triggerPipeline(buildOptions.afterBuildPipelineId, 'cli', {
-                ...deploy.env,
-                ...{ TAG: ecrRepoTag },
-                ...{ branch: branchName },
-              });
-              const afterBuildLog = {
+              const completed = await this.runAfterBuildPipeline({
+                deploy,
+                runUUID,
                 afterBuildPipelineId: buildOptions.afterBuildPipelineId,
-                pipelineId: afterbuildPipeline,
-                imageTag: ecrRepoTag,
-              };
-              const afterBuildLogDetails =
-                `afterBuildPipelineId=${afterBuildLog.afterBuildPipelineId} ` +
-                `pipelineId=${afterBuildLog.pipelineId} imageTag=${afterBuildLog.imageTag}`;
-              const afterBuildLogger = getLogger(afterBuildLog);
-              afterBuildLogger.info(`Codefresh: after-build pipeline triggered ${afterBuildLogDetails}`);
-
-              if (!runIsCurrent || !(await this.isDeploymentRunCurrent(deploy, runUUID, expectedGeneration))) {
-                afterBuildLogger.info(
-                  `Codefresh: after-build pipeline detached reason=superseded ${afterBuildLogDetails}`
+                ecrRepoTag: constructEcrTag({ repo: ecrRepo, tag, ecrDomain }),
+                branchName,
+                sourceRevision: fullSha,
+              });
+              if (!(await this.isDeploymentRunCurrent(deploy, runUUID, expectedGeneration))) {
+                getLogger().info(
+                  `Image: after-build publication skipped reason=superseded result=${completed ? 'success' : 'failure'}`
                 );
                 return true;
               }
-
-              const completed = await codefresh.waitForImage(afterbuildPipeline);
               if (!completed) {
-                afterBuildLogger.warn(
-                  `Codefresh: after-build pipeline completed result=failure ${afterBuildLogDetails}`
-                );
+                await this.patchAndUpdateActivityFeed(deploy, { status: DeployStatus.BUILD_FAILED }, runUUID);
                 return false;
               }
-              afterBuildLogger.info(`Codefresh: after-build pipeline completed result=success ${afterBuildLogDetails}`);
             }
+
+            await this.patchDeployWithTag({ tag, initTag, deploy, ecrDomain, runUUID });
             return true;
           } else {
             if (!runIsCurrent) return true;
@@ -1275,6 +1286,15 @@ export default class DeployService extends BaseService {
         await this.patchDeployForRun(deploy, runUUID, { buildOutput });
 
         if (buildSuccess) {
+          if (buildOptions?.afterBuildPipelineId && !deployable.detatchAfterBuildPipeline) {
+            // A non-detached embedded PostBuild must succeed for the parent pipeline to succeed.
+            await this.patchDeployForRun(deploy, runUUID, {
+              afterBuildCompletionKey: this.afterBuildCompletionKeyFor(
+                buildOptions.afterBuildPipelineId,
+                constructEcrTag({ repo: ecrRepo, tag, ecrDomain })
+              ),
+            });
+          }
           await this.patchDeployWithTag({ tag, initTag, deploy, ecrDomain, runUUID });
           getLogger().info('Image: built');
           return true;
@@ -1300,6 +1320,32 @@ export default class DeployService extends BaseService {
           if (!(await this.isDeploymentRunCurrent(deploy, runUUID, expectedGeneration))) {
             getLogger().info('Image: stopped after secret sync reason=superseded');
             return true;
+          }
+        }
+
+        // An existing image is not proof its after-build ran; the recorded completion is.
+        if (deployable.afterBuildPipelineId) {
+          const ecrRepoTag = constructEcrTag({ repo: ecrRepo, tag, ecrDomain });
+          const completionKey = this.afterBuildCompletionKeyFor(deployable.afterBuildPipelineId, ecrRepoTag);
+          if (deploy.afterBuildCompletionKey !== completionKey) {
+            const completed = await this.runAfterBuildPipeline({
+              deploy,
+              runUUID,
+              afterBuildPipelineId: deployable.afterBuildPipelineId,
+              ecrRepoTag,
+              branchName,
+              sourceRevision: fullSha,
+            });
+            if (!(await this.isDeploymentRunCurrent(deploy, runUUID, expectedGeneration))) {
+              getLogger().info(
+                `Image: after-build publication skipped reason=superseded result=${completed ? 'success' : 'failure'}`
+              );
+              return true;
+            }
+            if (!completed) {
+              await this.patchAndUpdateActivityFeed(deploy, { status: DeployStatus.BUILD_FAILED }, runUUID);
+              return false;
+            }
           }
         }
         await this.patchDeployWithTag({ tag, initTag, deploy, ecrDomain, runUUID });


### PR DESCRIPTION
## Issue

Services can declare an `afterBuildPipelineId`: a pipeline that must run after the image build
for the deployed image to actually work (for example, publishing build artifacts the running
service depends on). That pipeline was only ever triggered by the run that built the image, and
the image-exists check (`tagsExist`) assumed a present tag meant all build work was done:

- If the building run was superseded or crashed between pushing the image and its after-build
  completing, the image was left permanently unprocessed. Every later pass — including manual
  redeploys — found the tag, skipped the pipeline, and deployed anyway. There was no recovery
  path short of deleting the image tag to force a rebuild.
- Codefresh-builder cache hits never ran or verified the pipeline at all.
- A superseded run could fire the pipeline without awaiting it, so its outcome was never
  observed and deploys could race it.

## Fix

An image is only deployable when its after-build pipeline is proven to have run.

- A successful, awaited pipeline run is recorded on the deploy
  (`afterBuildCompletionKey` = `pipelineId@imageTag`, migration 033). A Codefresh-engine build
  also records it on success when its embedded post-build step is non-detached, since that
  step's failure fails the parent pipeline. The record is cleared, fail-closed, before any
  rebuild of the same tag.
- The image-exists path requires a matching record. Missing or mismatched → the pipeline is
  triggered and awaited before BUILT (any builder engine); failure records BUILD_FAILED and
  blocks rollout. Matching → skipped, so redeploys of already-verified services don't re-run it.
- Fresh builds publish BUILT only after the pipeline succeeds, and record BUILD_FAILED when it
  doesn't.
- Superseded runs publish and trigger nothing; the current run owns the pipeline, and currency
  is rechecked after every pipeline wait so a stale run can't publish state.
- The pipeline receives both historical invocation contracts' variables (`branch` plus
  `SOURCE_REVISION`/`SOURCE_BRANCH`).

The record is only ever an optimization: a missing or stale record causes a re-run, never a
skip. This relies on two contracts already implicit in tag-level build dedupe — an image tag
(sha + env hash) identifies equivalent build outputs, and after-build pipelines are idempotent
per image tag.

After deploying this change, the first pass over each environment re-runs its after-build
services' pipelines once (no recorded completions exist yet), then goes quiet.