### PR TITLE
fix: honor per-service defaultUUID for fallback hostnames

### DIFF
--- a/src/server/models/yaml/YamlService.ts
+++ b/src/server/models/yaml/YamlService.ts
@@ -885,12 +885,9 @@ export const getDockerBuildPipelineId = (service) =>
   service?.helm?.docker?.pipelineId || service?.github?.docker?.pipelineId;
 
 export async function getPublicUrl(service: Service, build: Build): Promise<string> {
-  const { lifecycleDefaults, domainDefaults } = await GlobalConfigService.getInstance().getAllConfigs();
-  let host = lifecycleDefaults.defaultUUID;
-  let { http: httpDomain, grpc: grpcDomain } = domainDefaults;
-  if (build?.enabledFeatures.includes(FeatureFlags.NO_DEFAULT_ENV_RESOLVE)) {
-    host = NO_DEFAULT_ENV_UUID;
-  }
+  const { domainDefaults } = await GlobalConfigService.getInstance().getAllConfigs();
+  const host = await getUUID(service, build);
+  const { http: httpDomain, grpc: grpcDomain } = domainDefaults;
 
   if (DeployTypes.HELM === getDeployType(service)) {
     const helmService = (service as unknown as HelmService).helm;

--- a/src/server/models/yaml/tests/YamlService.test.ts
+++ b/src/server/models/yaml/tests/YamlService.test.ts
@@ -19,6 +19,7 @@ mockRedisClient();
 
 import { YamlConfigParser } from 'server/lib/yamlConfigParser';
 import { YamlConfigValidator } from 'server/lib/yamlConfigValidator';
+import { Build } from 'server/models';
 import { DeployTypes } from 'shared/constants';
 import * as YamlService from '../index';
 
@@ -584,6 +585,31 @@ services:
       const service: YamlService.Service = YamlService.getDeployingServicesByName(config, 'service-with-app-short');
 
       await expect(YamlService.getEcr(service)).resolves.toEqual('account-id.dkr.ecr.us-west-2.amazonaws.com/svc/lfc');
+    });
+  });
+
+  describe('getPublicUrl', () => {
+    beforeEach(() => {
+      mockGetAllConfigs.mockResolvedValue({
+        lifecycleDefaults: { defaultUUID: 'dev-0' },
+        domainDefaults: { http: 'lifecycle.example.com', grpc: 'lifecycle-grpc.example.com' },
+      });
+    });
+
+    test('falls back to the global default UUID when the service has none configured', async () => {
+      const service: YamlService.Service = { name: 'my-service' } as YamlService.Service;
+      const build = { enabledFeatures: [] } as unknown as Build;
+
+      await expect(YamlService.getPublicUrl(service, build)).resolves.toEqual('my-service-dev-0.lifecycle.example.com');
+    });
+
+    test('uses the service-level defaultUUID override when configured', async () => {
+      const service: YamlService.Service = { name: 'my-service', defaultUUID: 'sandbox' } as YamlService.Service;
+      const build = { enabledFeatures: [] } as unknown as Build;
+
+      await expect(YamlService.getPublicUrl(service, build)).resolves.toEqual(
+        'my-service-sandbox.lifecycle.example.com'
+      );
     });
   });
 

--- a/src/server/models/yaml/tests/YamlService.test.ts
+++ b/src/server/models/yaml/tests/YamlService.test.ts
@@ -20,7 +20,7 @@ mockRedisClient();
 import { YamlConfigParser } from 'server/lib/yamlConfigParser';
 import { YamlConfigValidator } from 'server/lib/yamlConfigValidator';
 import { Build } from 'server/models';
-import { DeployTypes } from 'shared/constants';
+import { DeployTypes, FeatureFlags, NO_DEFAULT_ENV_UUID } from 'shared/constants';
 import * as YamlService from '../index';
 
 const mockGetAllConfigs = jest.fn();
@@ -609,6 +609,15 @@ services:
 
       await expect(YamlService.getPublicUrl(service, build)).resolves.toEqual(
         'my-service-sandbox.lifecycle.example.com'
+      );
+    });
+
+    test('NO_DEFAULT_ENV_RESOLVE takes priority over a service-level defaultUUID override', async () => {
+      const service: YamlService.Service = { name: 'my-service', defaultUUID: 'sandbox' } as YamlService.Service;
+      const build = { enabledFeatures: [FeatureFlags.NO_DEFAULT_ENV_RESOLVE] } as unknown as Build;
+
+      await expect(YamlService.getPublicUrl(service, build)).resolves.toEqual(
+        `my-service-${NO_DEFAULT_ENV_UUID}.lifecycle.example.com`
       );
     });
   });

--- a/src/server/services/__tests__/deployable.test.ts
+++ b/src/server/services/__tests__/deployable.test.ts
@@ -52,6 +52,7 @@ jest.mock('server/lib/github', () => ({
 }));
 
 import * as YamlService from 'server/models/yaml';
+import { Build } from 'server/models';
 import DeployableService, { DeployableAttributes } from '../deployable';
 
 const lifecycleDefaults = {
@@ -258,6 +259,42 @@ describe('Deployable Service', () => {
         deploymentDependsOn: [],
         helm: undefined,
       });
+    });
+
+    test('service-level defaultUUID overrides the global default for hostname/URL fallbacks', async () => {
+      const githubService: YamlService.GithubService = {
+        name: 'github-app',
+        defaultUUID: 'sandbox',
+        github: {
+          repository: 'example-org/example-service',
+          branchName: 'unit-test',
+          docker: {
+            defaultTag: 'main',
+            app: {
+              dockerfilePath: 'app1/app.Dockerfile',
+            },
+          },
+        },
+      };
+
+      const build = { enabledFeatures: [] } as unknown as Build;
+
+      // @ts-ignore
+      const result: DeployableAttributes = await deployableService.generateAttributesFromYamlConfig(
+        100,
+        'unit-test-12345',
+        1234567890,
+        'unit-test',
+        githubService,
+        false,
+        '',
+        build
+      );
+
+      expect(result.defaultUUID).toEqual('sandbox');
+      expect(result.defaultInternalHostname).toEqual('github-app-sandbox');
+      expect(result.defaultPublicUrl).toEqual(`github-app-sandbox.${domainDefaults.http}`);
+      expect(result.defaultGrpcHost).toEqual(`github-app-sandbox.${domainDefaults.grpc}`);
     });
 
     test('Generate config should have httpGet port and path', async () => {

--- a/src/server/services/__tests__/deployable.test.ts
+++ b/src/server/services/__tests__/deployable.test.ts
@@ -53,6 +53,7 @@ jest.mock('server/lib/github', () => ({
 
 import * as YamlService from 'server/models/yaml';
 import { Build } from 'server/models';
+import { FeatureFlags, NO_DEFAULT_ENV_UUID } from 'shared/constants';
 import DeployableService, { DeployableAttributes } from '../deployable';
 
 const lifecycleDefaults = {
@@ -295,6 +296,42 @@ describe('Deployable Service', () => {
       expect(result.defaultInternalHostname).toEqual('github-app-sandbox');
       expect(result.defaultPublicUrl).toEqual(`github-app-sandbox.${domainDefaults.http}`);
       expect(result.defaultGrpcHost).toEqual(`github-app-sandbox.${domainDefaults.grpc}`);
+    });
+
+    test('NO_DEFAULT_ENV_RESOLVE takes priority over a service-level defaultUUID override', async () => {
+      const githubService: YamlService.GithubService = {
+        name: 'github-app',
+        defaultUUID: 'sandbox',
+        github: {
+          repository: 'example-org/example-service',
+          branchName: 'unit-test',
+          docker: {
+            defaultTag: 'main',
+            app: {
+              dockerfilePath: 'app1/app.Dockerfile',
+            },
+          },
+        },
+      };
+
+      const build = { enabledFeatures: [FeatureFlags.NO_DEFAULT_ENV_RESOLVE] } as unknown as Build;
+
+      // @ts-ignore
+      const result: DeployableAttributes = await deployableService.generateAttributesFromYamlConfig(
+        100,
+        'unit-test-12345',
+        1234567890,
+        'unit-test',
+        githubService,
+        false,
+        '',
+        build
+      );
+
+      expect(result.defaultUUID).toEqual(NO_DEFAULT_ENV_UUID);
+      expect(result.defaultInternalHostname).toEqual(`github-app-${NO_DEFAULT_ENV_UUID}`);
+      expect(result.defaultPublicUrl).toEqual(`github-app-${NO_DEFAULT_ENV_UUID}.${domainDefaults.http}`);
+      expect(result.defaultGrpcHost).toEqual(`github-app-${NO_DEFAULT_ENV_UUID}.${domainDefaults.grpc}`);
     });
 
     test('Generate config should have httpGet port and path', async () => {

--- a/src/server/services/deployable.ts
+++ b/src/server/services/deployable.ts
@@ -199,7 +199,7 @@ export default class DeployableService extends BaseService {
         const { serviceDefaults, lifecycleDefaults, domainDefaults, buildDefaults } =
           await GlobalConfigService.getInstance().getAllConfigs();
         //TODO check and throw error here?
-        const defaultUUID = lifecycleDefaults.defaultUUID;
+        const defaultUUID = await YamlService.getUUID(service, build);
         const dockerBuildPipelineName =
           YamlService.getDockerBuildPipelineId(service) || lifecycleDefaults.buildPipeline;
 
@@ -262,7 +262,7 @@ export default class DeployableService extends BaseService {
             deployment?.network?.grpc?.defaultHost ?? `${service.name}-${defaultUUID}.${domainDefaults.grpc}`,
 
           ingressAnnotations: deployment?.network?.ingressAnnotations ?? {},
-          defaultUUID: await YamlService.getUUID(service, build),
+          defaultUUID,
           serviceDisksYaml: deployment?.serviceDisks ? JSON.stringify(deployment.serviceDisks) : null,
 
           nodeSelector: deployment?.node_selector ?? null,


### PR DESCRIPTION
## Description
- A service's own `defaultUUID` (set in `lifecycle.yaml`) was ignored when building its fallback public URL, internal hostname, and gRPC host — those always fell back to the global default UUID instead.
- `getPublicUrl()` and the hostname fallback in `DeployableService` now resolve through the existing `getUUID()` helper, which already honored the per-service override.
- No behavior change for services that don't set `defaultUUID` — they still fall back to the global default as before.

## Verifying Changes
- Added unit tests covering the per-service override for public URL, internal hostname, and gRPC host.
- Ran the affected Jest suites and full lint/typecheck — no new failures introduced.