### PR TITLE
feat: expose PR comment id on build API

### DIFF
--- a/src/server/services/__tests__/build.test.ts
+++ b/src/server/services/__tests__/build.test.ts
@@ -2153,6 +2153,18 @@ describe('BuildService focused changed-line coverage', () => {
       'grpc',
       'hostPortMapping'
     );
+    expect(graphSelect).toHaveBeenCalledWith(
+      'id',
+      'title',
+      'fullName',
+      'githubLogin',
+      'pullRequestNumber',
+      'branchName',
+      'status',
+      'labels',
+      'deployOnUpdate',
+      'commentId'
+    );
   });
 
   test('builds every supported image type and ignores inactive and unsupported deploys', async () => {

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -510,7 +510,8 @@ export default class BuildService extends BaseService {
           'branchName',
           'status',
           'labels',
-          'deployOnUpdate'
+          'deployOnUpdate',
+          'commentId'
         );
       })
       .modifyGraph('baseBuild', (b) => {

--- a/src/shared/openApiSpec.ts
+++ b/src/shared/openApiSpec.ts
@@ -5096,7 +5096,17 @@ export const openApiSpecificationForV2Api: OAS3Options = {
               example: 123456789,
             },
           },
-          required: ['id', 'title', 'fullName', 'githubLogin', 'pullRequestNumber', 'branchName', 'status', 'labels'],
+          required: [
+            'id',
+            'title',
+            'fullName',
+            'githubLogin',
+            'pullRequestNumber',
+            'branchName',
+            'status',
+            'labels',
+            'commentId',
+          ],
         },
 
         /**

--- a/src/shared/openApiSpec.ts
+++ b/src/shared/openApiSpec.ts
@@ -5089,6 +5089,12 @@ export const openApiSpecificationForV2Api: OAS3Options = {
               type: 'array',
               items: { type: 'string', example: 'lifecycle-deploy!' },
             },
+            commentId: {
+              type: 'integer',
+              nullable: true,
+              description: "GitHub comment ID of Lifecycle's mission control comment on this PR, if posted yet.",
+              example: 123456789,
+            },
           },
           required: ['id', 'title', 'fullName', 'githubLogin', 'pullRequestNumber', 'branchName', 'status', 'labels'],
         },


### PR DESCRIPTION
## What

Adds `commentId` to the `pullRequest` object returned by `GET /api/v2/builds/{uuid}`.

## Why

The UI wants to let users jump straight from a build to Lifecycle's status comment on the PR. That comment's GitHub ID is already tracked on the `pull_requests` table but wasn't exposed over the API.

## Verifying Changes

- Lint and targeted unit tests pass on the changed files.
- No API behavior change beyond the additional (nullable) field.
