### PR TITLE
fix: keep the pull request comment in sync when a config change skips redeploy

### DIFF
--- a/src/app/api/v2/environments/[uuid]/route.ts
+++ b/src/app/api/v2/environments/[uuid]/route.ts
@@ -62,7 +62,9 @@ import {
  *     description: >
  *       Applies config overrides on top of lifecycle.yaml via the same override
  *       machinery PR comments and the UI use. Secret references are rejected in
- *       env values. Optionally pauses/resumes deploys via deployEnabled.
+ *       env values. Optionally pauses/resumes deploys via deployEnabled. The
+ *       response reports whether this request queued a redeploy, since a
+ *       service-override change can be a no-op if it matches the current state.
  *     tags: [Environments]
  *     operationId: patchEnvironment
  *     parameters:
@@ -94,10 +96,10 @@ import {
  *               trackDefaultBranches: { type: boolean }
  *     responses:
  *       '200':
- *         description: Updated environment detail.
+ *         description: Updated environment detail, plus whether this request queued a redeploy.
  *         content:
  *           application/json:
- *             schema: { $ref: '#/components/schemas/EnvironmentDetailSuccessResponse' }
+ *             schema: { $ref: '#/components/schemas/EnvironmentPatchSuccessResponse' }
  *       '400': { description: Invalid request body (invalid_body). }
  *       '404': { description: Environment not found. }
  *       '409': { description: Teardown already owns the environment (env_tearing_down). }
@@ -182,7 +184,7 @@ const patchHandler = createPrincipalApiHandler(
       });
     }
 
-    await buildService.applyApiEnvironmentPatch(build, override, {
+    const patchResult = await buildService.applyApiEnvironmentPatch(build, override, {
       services: services ?? null,
       env: env ?? null,
       initEnv: initEnv ?? null,
@@ -195,7 +197,16 @@ const patchHandler = createPrincipalApiHandler(
     if (!detail) {
       throw new NotFoundError(`Environment ${uuid} was not found.`, 'env_not_found');
     }
-    return successResponse(detail, { status: 200 }, req);
+    const redeployQueued = patchResult.mode === 'redeploy_queued';
+    return successResponse(
+      {
+        ...detail,
+        redeployQueued,
+        ...(redeployQueued ? { deployId: patchResult.deployId } : {}),
+      },
+      { status: 200 },
+      req
+    );
   }
 );
 

--- a/src/app/api/v2/environments/__tests__/environments-api-acceptance.test.ts
+++ b/src/app/api/v2/environments/__tests__/environments-api-acceptance.test.ts
@@ -595,6 +595,7 @@ describe('PATCH /api/v2/environments/{uuid}', () => {
     const build = { uuid: 'x', pullRequest: null, deploys: [] };
     mockBuildLookup(build);
     mockGetEnvironmentDetail.mockResolvedValue({ uuid: 'x', status: 'deployed' });
+    mockApplyApiEnvironmentPatch.mockResolvedValue({ mode: 'applied', changed: true, build });
 
     const res = await patchEnvironment(
       request('PATCH', { deployEnabled: false, env: { A: 'b' } }, 'http://localhost/api/v2/environments/x'),
@@ -610,11 +611,53 @@ describe('PATCH /api/v2/environments/{uuid}', () => {
     expect(mockGetEnvironmentDetail).toHaveBeenCalledWith('x', 101);
   });
 
+  it('reports redeployQueued as false with no deployId when the patch is applied without queueing', async () => {
+    writeToken();
+    const build = { uuid: 'x', pullRequest: null, deploys: [] };
+    mockBuildLookup(build);
+    mockGetEnvironmentDetail.mockResolvedValue({ uuid: 'x', status: 'deployed' });
+    mockApplyApiEnvironmentPatch.mockResolvedValue({ mode: 'applied', changed: true, build });
+
+    const res = await patchEnvironment(
+      request('PATCH', { env: { A: 'b' } }, 'http://localhost/api/v2/environments/x'),
+      { params: { uuid: 'x' } }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.redeployQueued).toBe(false);
+    expect(body.data).not.toHaveProperty('deployId');
+  });
+
+  it('reports redeployQueued and the deployId when the patch queues a redeploy', async () => {
+    writeToken();
+    const build = { uuid: 'x', pullRequest: null, deploys: [] };
+    mockBuildLookup(build);
+    mockGetEnvironmentDetail.mockResolvedValue({ uuid: 'x', status: 'deployed' });
+    mockApplyApiEnvironmentPatch.mockResolvedValue({
+      mode: 'redeploy_queued',
+      changed: true,
+      deployId: 'run-123',
+      build,
+    });
+
+    const res = await patchEnvironment(
+      request('PATCH', { services: [{ name: 'web', active: false }] }, 'http://localhost/api/v2/environments/x'),
+      { params: { uuid: 'x' } }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.redeployQueued).toBe(true);
+    expect(body.data.deployId).toBe('run-123');
+  });
+
   it('keeps omitted PATCH fields as no-ops', async () => {
     writeToken();
     const build = { id: 606, uuid: 'x', pullRequest: null, deploys: [] };
     mockBuildLookup(build);
     mockGetEnvironmentDetail.mockResolvedValue({ uuid: 'x', status: 'deployed' });
+    mockApplyApiEnvironmentPatch.mockResolvedValue({ mode: 'applied', changed: false, build });
 
     const res = await patchEnvironment(request('PATCH', {}, 'http://localhost/api/v2/environments/x'), {
       params: { uuid: 'x' },

--- a/src/server/lib/comment.ts
+++ b/src/server/lib/comment.ts
@@ -17,18 +17,8 @@
 import { getLogger } from './logger';
 import { BuildKind, CommentParser } from 'shared/constants';
 import { compact, flatten, set } from 'lodash';
-import type { Redis } from 'ioredis';
-import type Redlock from 'redlock';
-import type Database from 'server/database';
-import type QueueManager from 'server/lib/queueManager';
+import type Service from 'server/services/_service';
 import type { Build, PullRequest } from 'server/models';
-
-interface MissionControlRefreshDeps {
-  db: Database;
-  redis: Redis;
-  redlock: Redlock;
-  queueManager: QueueManager;
-}
 
 /**
  * Only build and deploy status transitions normally rebuild the Mission Control comment, so a
@@ -37,7 +27,7 @@ interface MissionControlRefreshDeps {
  * patch aggregates its sub-calls while the per-build routes refresh per call.
  */
 export async function refreshMissionControlComment(
-  { db, redis, redlock, queueManager }: MissionControlRefreshDeps,
+  service: Service,
   build: Build,
   pullRequest: PullRequest | null | undefined = build?.pullRequest
 ): Promise<void> {
@@ -46,6 +36,7 @@ export async function refreshMissionControlComment(
   }
 
   try {
+    const { db, redis, redlock, queueManager } = service;
     const activityStream =
       db.services?.ActivityStream ??
       new (await import('server/services/activityStream')).default(db, redis, redlock, queueManager);

--- a/src/server/lib/comment.ts
+++ b/src/server/lib/comment.ts
@@ -15,8 +15,47 @@
  */
 
 import { getLogger } from './logger';
-import { CommentParser } from 'shared/constants';
+import { BuildKind, CommentParser } from 'shared/constants';
 import { compact, flatten, set } from 'lodash';
+import type { Redis } from 'ioredis';
+import type Redlock from 'redlock';
+import type Database from 'server/database';
+import type QueueManager from 'server/lib/queueManager';
+import type { Build, PullRequest } from 'server/models';
+
+interface MissionControlRefreshDeps {
+  db: Database;
+  redis: Redis;
+  redlock: Redlock;
+  queueManager: QueueManager;
+}
+
+/**
+ * Only build and deploy status transitions normally rebuild the Mission Control comment, so a
+ * config change that queues no redeploy would leave it stale — and editing that stale comment
+ * would then reapply the old state. Callers decide when this applies, since the environments
+ * patch aggregates its sub-calls while the per-build routes refresh per call.
+ */
+export async function refreshMissionControlComment(
+  { db, redis, redlock, queueManager }: MissionControlRefreshDeps,
+  build: Build,
+  pullRequest: PullRequest | null | undefined = build?.pullRequest
+): Promise<void> {
+  if (!pullRequest || build?.kind === BuildKind.SANDBOX) {
+    return;
+  }
+
+  try {
+    const activityStream =
+      db.services?.ActivityStream ??
+      new (await import('server/services/activityStream')).default(db, redis, redlock, queueManager);
+
+    // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
+    await activityStream.updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true);
+  } catch (error) {
+    getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
+  }
+}
 
 export class CommentHelper {
   public static parseServiceBranches(comment: string): Array<{

--- a/src/server/services/__tests__/apiEnvironment.test.ts
+++ b/src/server/services/__tests__/apiEnvironment.test.ts
@@ -18,6 +18,7 @@ const mockGetAllConfigs = jest.fn();
 const mockGetApiEnvironmentsConfig = jest.fn();
 const mockGetYamlFileContent = jest.fn();
 const mockApplyServiceOverrides = jest.fn();
+const mockUpdatePullRequestActivityStream = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('server/lib/dependencies', () => ({
   defaultDb: {},
@@ -92,6 +93,12 @@ jest.mock('server/services/deployCleanup', () =>
 jest.mock('server/services/deploy', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({ patchAndUpdateActivityFeed: jest.fn() })),
+}));
+jest.mock('server/services/activityStream', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    updatePullRequestActivityStream: mockUpdatePullRequestActivityStream,
+  })),
 }));
 jest.mock('server/services/webhook', () => ({
   __esModule: true,
@@ -1902,6 +1909,55 @@ describe('applyApiEnvironmentPatch', () => {
       uuid: build.uuid,
       kind: BuildKind.ENVIRONMENT,
     });
+  });
+
+  it('refreshes the mission control comment when a config change does not queue a redeploy', async () => {
+    const { service, models } = makeService();
+    const override = overrideMock();
+    const build = {
+      ...apiBuild(),
+      triggerType: 'github_pr',
+      pullRequest: { deployOnUpdate: false },
+      commentRuntimeEnv: {},
+    };
+    allowMutableBuild(models, build);
+
+    const result = await service.applyApiEnvironmentPatch(build, override as any, {
+      env: { A: 'b' },
+    });
+
+    expect(result).toEqual({ mode: 'applied', changed: true, build });
+    expect(mockUpdatePullRequestActivityStream).toHaveBeenCalledWith(
+      build,
+      [],
+      build.pullRequest,
+      null,
+      true,
+      true,
+      null,
+      true
+    );
+  });
+
+  it('does not duplicate the comment refresh when the config change already queues a redeploy', async () => {
+    const { service, models } = makeService();
+    const override = overrideMock();
+    const build = {
+      ...apiBuild(),
+      triggerType: 'github_pr',
+      pullRequest: { deployOnUpdate: true },
+      commentRuntimeEnv: {},
+    };
+    allowMutableBuild(models, build);
+    const enqueue = jest.spyOn(service, 'enqueueResolveAndDeployBuild').mockResolvedValue(undefined as any);
+
+    const result = await service.applyApiEnvironmentPatch(build, override as any, {
+      env: { A: 'b' },
+    });
+
+    expect(enqueue).toHaveBeenCalled();
+    expect(result.mode).toBe('redeploy_queued');
+    expect(mockUpdatePullRequestActivityStream).not.toHaveBeenCalled();
   });
 
   it('merges and null-deletes individual MCP env keys inside the locked patch', async () => {

--- a/src/server/services/__tests__/override.test.ts
+++ b/src/server/services/__tests__/override.test.ts
@@ -21,6 +21,7 @@ const mockLogger = {
   warn: jest.fn(),
 };
 const mockFallbackEnqueueResolveAndDeployBuild = jest.fn();
+const mockUpdatePullRequestActivityStream = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('server/lib/dependencies', () => ({
   defaultDb: {},
@@ -52,6 +53,13 @@ jest.mock('../build', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({
     enqueueResolveAndDeployBuild: mockFallbackEnqueueResolveAndDeployBuild,
+  })),
+}));
+
+jest.mock('../activityStream', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    updatePullRequestActivityStream: mockUpdatePullRequestActivityStream,
   })),
 }));
 
@@ -414,6 +422,59 @@ describe('OverrideService.applyBuildOverrides', () => {
       queued: false,
       status: 'success',
     });
+  });
+
+  it('refreshes the mission control comment when service overrides change but deploy is disabled', async () => {
+    const { service, enqueueResolveAndDeployBuild } = createService();
+    const args = createFullYamlArgs();
+    args.pullRequest = { deployOnUpdate: false } as any;
+
+    const result = await service.applyServiceOverrides({
+      build: args.build,
+      deploys: args.deploys,
+      pullRequest: args.pullRequest,
+      serviceOverrides: [
+        {
+          name: 'api',
+          active: false,
+        },
+      ],
+      runUuid: 'run-uuid',
+    });
+
+    expect(enqueueResolveAndDeployBuild).not.toHaveBeenCalled();
+    expect(result.queued).toBe(false);
+    expect(mockUpdatePullRequestActivityStream).toHaveBeenCalledWith(
+      args.build,
+      [],
+      args.pullRequest,
+      null,
+      true,
+      true,
+      null,
+      true
+    );
+  });
+
+  it('does not duplicate the comment refresh when service overrides already queue a redeploy', async () => {
+    const { service, enqueueResolveAndDeployBuild } = createService();
+    const args = createFullYamlArgs();
+
+    await service.applyServiceOverrides({
+      build: args.build,
+      deploys: args.deploys,
+      pullRequest: args.pullRequest,
+      serviceOverrides: [
+        {
+          name: 'api',
+          active: false,
+        },
+      ],
+      runUuid: 'run-uuid',
+    });
+
+    expect(enqueueResolveAndDeployBuild).toHaveBeenCalled();
+    expect(mockUpdatePullRequestActivityStream).not.toHaveBeenCalled();
   });
 
   it('applies branch-only service overrides without changing dependents', async () => {
@@ -925,6 +986,28 @@ describe('OverrideService.applyBuildConfigPatch', () => {
     await service.applyBuildConfigPatch(args);
 
     expect(enqueueResolveAndDeployBuild).not.toHaveBeenCalled();
+    expect(mockUpdatePullRequestActivityStream).toHaveBeenCalledWith(
+      args.build,
+      [],
+      args.pullRequest,
+      null,
+      true,
+      true,
+      null,
+      true
+    );
+  });
+
+  it('does not duplicate the comment refresh when the config change already queues a redeploy', async () => {
+    const { service, enqueueResolveAndDeployBuild } = createService();
+    const args = createBuildConfigPatchArgs({
+      isStatic: true,
+    });
+
+    await service.applyBuildConfigPatch(args);
+
+    expect(enqueueResolveAndDeployBuild).toHaveBeenCalled();
+    expect(mockUpdatePullRequestActivityStream).not.toHaveBeenCalled();
   });
 
   it('patches build config without queueing when the build has no pull request', async () => {

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -1861,7 +1861,7 @@ export default class BuildService extends BaseService {
         };
       });
 
-    return this.withBuildDeploymentLock(build.id, async () => {
+    const result = await this.withBuildDeploymentLock(build.id, async () => {
       const persisted = await persistPatch();
       if (persisted.queueRedeploy) {
         await this.enqueueResolveAndDeployBuild({
@@ -1870,11 +1870,15 @@ export default class BuildService extends BaseService {
         });
         return { mode: 'redeploy_queued', changed: true, deployId: runUuid, build: persisted.build };
       }
-      if (persisted.changed) {
-        await this.refreshMissionControlCommentIfNoRedeploy(persisted.build);
-      }
       return { mode: 'applied', changed: persisted.changed, build: persisted.build };
     });
+
+    // Outside the deployment lock: the refresh takes its own lock on the same build, so holding
+    // both would let a slow comment update block every other operation on this build.
+    if (result.mode === 'applied' && result.changed) {
+      await this.refreshMissionControlCommentIfNoRedeploy(result.build);
+    }
+    return result;
   }
 
   /** A patch that changes config but skips redeploy (e.g. deploy disabled) would otherwise leave the Mission Control comment stale. */
@@ -1884,16 +1888,16 @@ export default class BuildService extends BaseService {
       return;
     }
 
-    const activityStream =
-      this.db.services?.ActivityStream ??
-      new (await import('./activityStream')).default(this.db, this.redis, this.redlock, this.queueManager);
+    try {
+      const activityStream =
+        this.db.services?.ActivityStream ??
+        new (await import('./activityStream')).default(this.db, this.redis, this.redlock, this.queueManager);
 
-    // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
-    await activityStream
-      .updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true)
-      .catch((error) => {
-        getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
-      });
+      // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
+      await activityStream.updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true);
+    } catch (error) {
+      getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
+    }
   }
 
   /** Shared enqueue-delete helper: the expiry sweep and the TTL scanner drift-repair both call this. */

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -1870,8 +1870,30 @@ export default class BuildService extends BaseService {
         });
         return { mode: 'redeploy_queued', changed: true, deployId: runUuid, build: persisted.build };
       }
+      if (persisted.changed) {
+        await this.refreshMissionControlCommentIfNoRedeploy(persisted.build);
+      }
       return { mode: 'applied', changed: persisted.changed, build: persisted.build };
     });
+  }
+
+  /** A patch that changes config but skips redeploy (e.g. deploy disabled) would otherwise leave the Mission Control comment stale. */
+  private async refreshMissionControlCommentIfNoRedeploy(build: Build): Promise<void> {
+    const pullRequest = build.pullRequest;
+    if (!pullRequest || build.kind === BuildKind.SANDBOX) {
+      return;
+    }
+
+    const activityStream =
+      this.db.services?.ActivityStream ??
+      new (await import('./activityStream')).default(this.db, this.redis, this.redlock, this.queueManager);
+
+    // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
+    await activityStream
+      .updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true)
+      .catch((error) => {
+        getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
+      });
   }
 
   /** Shared enqueue-delete helper: the expiry sweep and the TTL scanner drift-repair both call this. */

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -1861,7 +1861,7 @@ export default class BuildService extends BaseService {
         };
       });
 
-    const result = await this.withBuildDeploymentLock(build.id, async () => {
+    const result = await this.withBuildDeploymentLock(build.id, async (): Promise<ApplyApiEnvironmentPatchResult> => {
       const persisted = await persistPatch();
       if (persisted.queueRedeploy) {
         await this.enqueueResolveAndDeployBuild({

--- a/src/server/services/build.ts
+++ b/src/server/services/build.ts
@@ -17,6 +17,7 @@
 import { createHash } from 'crypto';
 import Haikunator from 'haikunator';
 import * as k8s from 'server/lib/kubernetes';
+import { refreshMissionControlComment } from 'server/lib/comment';
 import * as cli from 'server/lib/cli';
 import * as github from 'server/lib/github';
 import { uninstallHelmReleases } from 'server/lib/helm';
@@ -1876,28 +1877,9 @@ export default class BuildService extends BaseService {
     // Outside the deployment lock: the refresh takes its own lock on the same build, so holding
     // both would let a slow comment update block every other operation on this build.
     if (result.mode === 'applied' && result.changed) {
-      await this.refreshMissionControlCommentIfNoRedeploy(result.build);
+      await refreshMissionControlComment(this, result.build);
     }
     return result;
-  }
-
-  /** A patch that changes config but skips redeploy (e.g. deploy disabled) would otherwise leave the Mission Control comment stale. */
-  private async refreshMissionControlCommentIfNoRedeploy(build: Build): Promise<void> {
-    const pullRequest = build.pullRequest;
-    if (!pullRequest || build.kind === BuildKind.SANDBOX) {
-      return;
-    }
-
-    try {
-      const activityStream =
-        this.db.services?.ActivityStream ??
-        new (await import('./activityStream')).default(this.db, this.redis, this.redlock, this.queueManager);
-
-      // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
-      await activityStream.updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true);
-    } catch (error) {
-      getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
-    }
   }
 
   /** Shared enqueue-delete helper: the expiry sweep and the TTL scanner drift-repair both call this. */

--- a/src/server/services/override.ts
+++ b/src/server/services/override.ts
@@ -22,7 +22,7 @@ import { Build, Deploy, PullRequest } from 'server/models';
 import * as k8s from 'server/lib/kubernetes';
 import DeployService from './deploy';
 import * as psl from 'psl';
-import { DeployTypes } from 'shared/constants';
+import { BuildKind, DeployTypes } from 'shared/constants';
 import type { Transaction } from 'objection';
 
 export interface ValidationResult {
@@ -267,7 +267,10 @@ export default class OverrideService extends BaseService {
     }
 
     if (enqueueRedeploy) {
-      await this.enqueueRedeployIfEnabled(updatedBuild, pullRequest, runUuid);
+      const queued = await this.enqueueRedeployIfEnabled(updatedBuild, pullRequest, runUuid);
+      if (!queued) {
+        await this.refreshMissionControlCommentIfNoRedeploy(updatedBuild, pullRequest);
+      }
     }
     return updatedBuild;
   }
@@ -316,6 +319,9 @@ export default class OverrideService extends BaseService {
     );
 
     const queued = enqueueRedeploy ? await this.enqueueRedeployIfEnabled(build, pullRequest, runUuid) : false;
+    if (enqueueRedeploy && !queued) {
+      await this.refreshMissionControlCommentIfNoRedeploy(build, pullRequest);
+    }
     return {
       buildUuid: build.uuid,
       queued,
@@ -530,6 +536,27 @@ export default class OverrideService extends BaseService {
       runUUID: runUuid,
     });
     return true;
+  }
+
+  /** A config change with no redeploy leaves the Mission Control comment stale, since only build/deploy status transitions normally refresh it. */
+  private async refreshMissionControlCommentIfNoRedeploy(
+    build: Build,
+    pullRequest: PullRequest | null | undefined
+  ): Promise<void> {
+    if (!pullRequest || build.kind === BuildKind.SANDBOX) {
+      return;
+    }
+
+    const activityStream =
+      this.db.services?.ActivityStream ??
+      new (await import('./activityStream')).default(this.db, this.redis, this.redlock, this.queueManager);
+
+    // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
+    await activityStream
+      .updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true)
+      .catch((error) => {
+        getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
+      });
   }
 
   /**

--- a/src/server/services/override.ts
+++ b/src/server/services/override.ts
@@ -17,12 +17,13 @@
 import BaseService from './_service';
 import { getLogger, updateLogContext } from 'server/lib/logger';
 import { isDeployEnabled } from 'server/lib/buildSource';
+import { refreshMissionControlComment } from 'server/lib/comment';
 import { validateBuildUuidFormat } from 'server/lib/validation/buildUuidValidator';
 import { Build, Deploy, PullRequest } from 'server/models';
 import * as k8s from 'server/lib/kubernetes';
 import DeployService from './deploy';
 import * as psl from 'psl';
-import { BuildKind, DeployTypes } from 'shared/constants';
+import { DeployTypes } from 'shared/constants';
 import type { Transaction } from 'objection';
 
 export interface ValidationResult {
@@ -269,7 +270,7 @@ export default class OverrideService extends BaseService {
     if (enqueueRedeploy) {
       const queued = await this.enqueueRedeployIfEnabled(updatedBuild, pullRequest, runUuid);
       if (!queued) {
-        await this.refreshMissionControlCommentIfNoRedeploy(updatedBuild, pullRequest);
+        await refreshMissionControlComment(this, updatedBuild, pullRequest);
       }
     }
     return updatedBuild;
@@ -320,7 +321,7 @@ export default class OverrideService extends BaseService {
 
     const queued = enqueueRedeploy ? await this.enqueueRedeployIfEnabled(build, pullRequest, runUuid) : false;
     if (enqueueRedeploy && !queued) {
-      await this.refreshMissionControlCommentIfNoRedeploy(build, pullRequest);
+      await refreshMissionControlComment(this, build, pullRequest);
     }
     return {
       buildUuid: build.uuid,
@@ -539,25 +540,6 @@ export default class OverrideService extends BaseService {
   }
 
   /** A config change with no redeploy leaves the Mission Control comment stale, since only build/deploy status transitions normally refresh it. */
-  private async refreshMissionControlCommentIfNoRedeploy(
-    build: Build,
-    pullRequest: PullRequest | null | undefined
-  ): Promise<void> {
-    if (!pullRequest || build.kind === BuildKind.SANDBOX) {
-      return;
-    }
-
-    try {
-      const activityStream =
-        this.db.services?.ActivityStream ??
-        new (await import('./activityStream')).default(this.db, this.redis, this.redlock, this.queueManager);
-
-      // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
-      await activityStream.updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true);
-    } catch (error) {
-      getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
-    }
-  }
 
   /**
    * Validate UUID format and uniqueness

--- a/src/server/services/override.ts
+++ b/src/server/services/override.ts
@@ -547,16 +547,16 @@ export default class OverrideService extends BaseService {
       return;
     }
 
-    const activityStream =
-      this.db.services?.ActivityStream ??
-      new (await import('./activityStream')).default(this.db, this.redis, this.redlock, this.queueManager);
+    try {
+      const activityStream =
+        this.db.services?.ActivityStream ??
+        new (await import('./activityStream')).default(this.db, this.redis, this.redlock, this.queueManager);
 
-    // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
-    await activityStream
-      .updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true)
-      .catch((error) => {
-        getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
-      });
+      // queue:true enqueues by pullRequest.id and returns before `repository` is read; the queued worker re-fetches its own graph.
+      await activityStream.updatePullRequestActivityStream(build, [], pullRequest, null, true, true, null, true);
+    } catch (error) {
+      getLogger().warn({ error }, 'Comment: mission control refresh failed after non-redeploy config change');
+    }
   }
 
   /**

--- a/src/shared/openApiSpec.test.ts
+++ b/src/shared/openApiSpec.test.ts
@@ -73,8 +73,13 @@ describe('OpenAPI v2 environment contract', () => {
       $ref: '#/components/schemas/EnvironmentDetailSuccessResponse',
     });
     expect(successSchema('/api/v2/environments/{uuid}', 'patch', '200')).toEqual({
-      $ref: '#/components/schemas/EnvironmentDetailSuccessResponse',
+      $ref: '#/components/schemas/EnvironmentPatchSuccessResponse',
     });
+    const patchResultExtension = schemas.EnvironmentPatchResult.allOf[1];
+    expect(patchResultExtension.properties.redeployQueued).toEqual(expect.objectContaining({ type: 'boolean' }));
+    expect(patchResultExtension.properties.deployId).toEqual(expect.objectContaining({ type: 'string' }));
+    expect(patchResultExtension.required).toContain('redeployQueued');
+    expect(patchResultExtension.required).not.toContain('deployId');
     expect(successSchema('/api/v2/environments/{uuid}', 'delete', '202')).toEqual({
       $ref: '#/components/schemas/EnvironmentQueuedOperationSuccessResponse',
     });

--- a/src/shared/openApiSpec.ts
+++ b/src/shared/openApiSpec.ts
@@ -708,6 +708,27 @@ export const openApiSpecificationForV2Api: OAS3Options = {
           ],
         },
 
+        EnvironmentPatchResult: {
+          allOf: [
+            { $ref: '#/components/schemas/EnvironmentDetail' },
+            {
+              type: 'object',
+              properties: {
+                redeployQueued: {
+                  type: 'boolean',
+                  description: 'Whether this request queued a redeploy for the environment.',
+                },
+                deployId: {
+                  type: 'string',
+                  description:
+                    'Identifier of the redeploy queued by this request. Present only when redeployQueued is true.',
+                },
+              },
+              required: ['redeployQueued'],
+            },
+          ],
+        },
+
         EnvironmentCreateResult: {
           type: 'object',
           properties: {
@@ -885,6 +906,17 @@ export const openApiSpecificationForV2Api: OAS3Options = {
             {
               type: 'object',
               properties: { data: { $ref: '#/components/schemas/EnvironmentDetail' } },
+              required: ['data'],
+            },
+          ],
+        },
+
+        EnvironmentPatchSuccessResponse: {
+          allOf: [
+            { $ref: '#/components/schemas/SuccessApiResponse' },
+            {
+              type: 'object',
+              properties: { data: { $ref: '#/components/schemas/EnvironmentPatchResult' } },
               required: ['data'],
             },
           ],


### PR DESCRIPTION
## What

Two changes to how environment config updates behave.

**The pull request comment could go stale.** The comment is rebuilt from the database, but that only happened when a build or deploy changed status. A config change on an environment with deploys paused updated the database and queued nothing, so the comment kept showing the old selections. Editing that stale comment then reapplied the old state and silently undid the change. The comment is now refreshed whenever a config change is applied without queueing a redeploy.

**The patch response did not say whether a redeploy started.** `PATCH /api/v2/environments/{uuid}` already knew, but threw the answer away, so clients had to guess from `deployEnabled`. That guess is wrong when the server drops the submitted overrides as no-ops. The response now carries `redeployQueued` and, when one started, `deployId`.

## Notes

The comment refresh is queued rather than rendered inline, and it runs after the build deployment lock is released. It takes its own lock on the same build, so holding both would let a slow comment update block other operations on that build. Any failure in it is caught and logged, so it cannot fail the config request.

`redeployQueued` and `deployId` are added as new schema components used only by the patch operation. The shared environment detail schema and the GET response are unchanged.

## Testing

Unit tests cover both outcomes for each change. Verified on a live environment: a config change with deploys paused returned `redeployQueued: false` and the comment refreshed within about 15 seconds, and a no-op patch returned `redeployQueued: false` while `deployEnabled` was still true.