### PR TITLE
feat: let every environment toggle default-branch tracking from its comment

### DIFF
--- a/src/server/lib/__tests__/comment.test.ts
+++ b/src/server/lib/__tests__/comment.test.ts
@@ -108,9 +108,8 @@ describe('CommentHelper.parseRedeployOnPushes', () => {
     expect(CommentHelper.parseRedeployOnPushes(line('x'))).toBe(true);
   });
 
-  test('tolerates uppercase, quoting, indentation and carriage returns', () => {
+  test('tolerates uppercase, indentation and carriage returns', () => {
     expect(CommentHelper.parseRedeployOnPushes(line('X'))).toBe(true);
-    expect(CommentHelper.parseRedeployOnPushes(`> ${line('x')}`)).toBe(true);
     expect(CommentHelper.parseRedeployOnPushes(`  ${line('x')}`)).toBe(true);
     expect(CommentHelper.parseRedeployOnPushes(`${line('x')}\r\nnext line`)).toBe(true);
   });
@@ -127,5 +126,20 @@ describe('CommentHelper.parseRedeployOnPushes', () => {
     ].join('\n');
 
     expect(CommentHelper.parseRedeployOnPushes(comment)).toBe(false);
+  });
+});
+
+describe('CommentHelper.parseRedeployOnPushes conflicting lines', () => {
+  test('reads the real list item, not a quoted copy', () => {
+    const comment = [
+      '> - [x] Redeploy on pushes to default branches',
+      '- [ ] Redeploy on pushes to default branches',
+    ].join('\n');
+
+    expect(CommentHelper.parseRedeployOnPushes(comment)).toBe(false);
+  });
+
+  test('ignores a quoted line when no real list item exists', () => {
+    expect(CommentHelper.parseRedeployOnPushes('> - [x] Redeploy on pushes to default branches')).toBeUndefined();
   });
 });

--- a/src/server/lib/__tests__/comment.test.ts
+++ b/src/server/lib/__tests__/comment.test.ts
@@ -87,3 +87,45 @@ describe('CommentHelper.parseEnvironmentOverrides', () => {
     });
   });
 });
+
+describe('CommentHelper.parseRedeployOnPushes', () => {
+  const line = (box: string) => `- [${box}] Redeploy on pushes to default branches`;
+
+  test('returns undefined when the option line is absent', () => {
+    const comment = ['Status comment', CommentParser.HEADER, '- [x] api: main', CommentParser.FOOTER].join('\n');
+
+    expect(CommentHelper.parseRedeployOnPushes(comment)).toBeUndefined();
+  });
+
+  test('returns undefined for prose mentioning the option without a checkbox', () => {
+    const comment = 'We should enable Redeploy on pushes to default branches for this environment.';
+
+    expect(CommentHelper.parseRedeployOnPushes(comment)).toBeUndefined();
+  });
+
+  test('distinguishes unchecked from checked', () => {
+    expect(CommentHelper.parseRedeployOnPushes(line(' '))).toBe(false);
+    expect(CommentHelper.parseRedeployOnPushes(line('x'))).toBe(true);
+  });
+
+  test('tolerates uppercase, quoting, indentation and carriage returns', () => {
+    expect(CommentHelper.parseRedeployOnPushes(line('X'))).toBe(true);
+    expect(CommentHelper.parseRedeployOnPushes(`> ${line('x')}`)).toBe(true);
+    expect(CommentHelper.parseRedeployOnPushes(`  ${line('x')}`)).toBe(true);
+    expect(CommentHelper.parseRedeployOnPushes(`${line('x')}\r\nnext line`)).toBe(true);
+  });
+
+  test('finds the option when it follows the rest of the comment body', () => {
+    const comment = [
+      CommentParser.HEADER,
+      '- [x] api: main',
+      CommentParser.FOOTER,
+      '## Actions',
+      '- [ ] Redeploy Environment',
+      '### Options',
+      line(' '),
+    ].join('\n');
+
+    expect(CommentHelper.parseRedeployOnPushes(comment)).toBe(false);
+  });
+});

--- a/src/server/lib/comment.ts
+++ b/src/server/lib/comment.ts
@@ -48,6 +48,11 @@ export async function refreshMissionControlComment(
   }
 }
 
+// Anchored to the task-list line itself, not the heading: clicking a checkbox rewrites only the box,
+// and prose elsewhere in the comment must never be mistaken for the option.
+const REDEPLOY_ON_PUSH_LINE = /^[ \t>]*[-*+] \[[ xX]\] Redeploy on pushes to default branches[ \t]*\r?$/m;
+const REDEPLOY_ON_PUSH_CHECKED = /^[ \t>]*[-*+] \[[xX]\] Redeploy on pushes to default branches[ \t]*\r?$/m;
+
 export class CommentHelper {
   public static parseServiceBranches(comment: string): Array<{
     active: boolean;
@@ -72,8 +77,15 @@ export class CommentHelper {
     return compact(flatten(serviceBranches));
   }
 
-  public static parseRedeployOnPushes(comment: string): boolean {
-    return comment.match(/\[x\] Redeploy on pushes to default branches/g) != null;
+  /**
+   * Undefined means the option line is absent, which is a stale or hand-trimmed comment body
+   * rather than an explicit "off". Callers must not persist that as false.
+   */
+  public static parseRedeployOnPushes(comment: string): boolean | undefined {
+    if (!REDEPLOY_ON_PUSH_LINE.test(comment ?? '')) {
+      return undefined;
+    }
+    return REDEPLOY_ON_PUSH_CHECKED.test(comment);
   }
 
   public static parseVanityUrl(comment: string): string {

--- a/src/server/lib/comment.ts
+++ b/src/server/lib/comment.ts
@@ -49,9 +49,9 @@ export async function refreshMissionControlComment(
 }
 
 // Anchored to the task-list line itself, not the heading: clicking a checkbox rewrites only the box,
-// and prose elsewhere in the comment must never be mistaken for the option.
-const REDEPLOY_ON_PUSH_LINE = /^[ \t>]*[-*+] \[[ xX]\] Redeploy on pushes to default branches[ \t]*\r?$/m;
-const REDEPLOY_ON_PUSH_CHECKED = /^[ \t>]*[-*+] \[[xX]\] Redeploy on pushes to default branches[ \t]*\r?$/m;
+// and prose elsewhere in the comment must never be mistaken for the option. Quoted lines are excluded
+// because GitHub does not render those as checkboxes.
+const REDEPLOY_ON_PUSH_LINE = /^[ \t]*[-*+] \[([ xX])\] Redeploy on pushes to default branches[ \t]*\r?$/m;
 
 export class CommentHelper {
   public static parseServiceBranches(comment: string): Array<{
@@ -82,10 +82,11 @@ export class CommentHelper {
    * rather than an explicit "off". Callers must not persist that as false.
    */
   public static parseRedeployOnPushes(comment: string): boolean | undefined {
-    if (!REDEPLOY_ON_PUSH_LINE.test(comment ?? '')) {
+    const match = REDEPLOY_ON_PUSH_LINE.exec(comment ?? '');
+    if (!match) {
       return undefined;
     }
-    return REDEPLOY_ON_PUSH_CHECKED.test(comment);
+    return match[1].toLowerCase() === 'x';
   }
 
   public static parseVanityUrl(comment: string): string {

--- a/src/server/lib/comment.ts
+++ b/src/server/lib/comment.ts
@@ -48,9 +48,7 @@ export async function refreshMissionControlComment(
   }
 }
 
-// Anchored to the task-list line itself, not the heading: clicking a checkbox rewrites only the box,
-// and prose elsewhere in the comment must never be mistaken for the option. Quoted lines are excluded
-// because GitHub does not render those as checkboxes.
+// Matches the list-item line only; quoted lines are not checkboxes on GitHub.
 const REDEPLOY_ON_PUSH_LINE = /^[ \t]*[-*+] \[([ xX])\] Redeploy on pushes to default branches[ \t]*\r?$/m;
 
 export class CommentHelper {
@@ -77,10 +75,7 @@ export class CommentHelper {
     return compact(flatten(serviceBranches));
   }
 
-  /**
-   * Undefined means the option line is absent, which is a stale or hand-trimmed comment body
-   * rather than an explicit "off". Callers must not persist that as false.
-   */
+  /** Undefined means the line is absent, which callers must not persist as false. */
   public static parseRedeployOnPushes(comment: string): boolean | undefined {
     const match = REDEPLOY_ON_PUSH_LINE.exec(comment ?? '');
     if (!match) {

--- a/src/server/services/__tests__/activityStream.test.ts
+++ b/src/server/services/__tests__/activityStream.test.ts
@@ -337,9 +337,10 @@ describe('ActivityStream comment edit ordering', () => {
     await service.updateBuildsAndDeploysFromCommentEdit(pullRequest, '- [x] Redeploy Environment');
 
     expect(calls).toEqual(['overrides', 'redeploy']);
+    const overrideArgs = applyCommentOverrides.mock.calls[0][0] as { runUuid: string };
     expect(enqueueResolveAndDeployBuild).toHaveBeenCalledWith({
       buildId: 42,
-      runUUID: applyCommentOverrides.mock.calls[0][0].runUuid,
+      runUUID: overrideArgs.runUuid,
     });
   });
 
@@ -350,6 +351,20 @@ describe('ActivityStream comment edit ordering', () => {
     await service.updateBuildsAndDeploysFromCommentEdit(pullRequest, '- [x] Redeploy Environment');
 
     expect(enqueueResolveAndDeployBuild).toHaveBeenCalledTimes(1);
+  });
+
+  it('still redeploys when a cache purge is requested in the same edit', async () => {
+    const { service, pullRequest, enqueueResolveAndDeployBuild } = createCommentEditFixture();
+    const purge = jest.spyOn(service as any, 'purgeFastlyServiceCache').mockResolvedValue(undefined);
+    jest.spyOn(service as any, 'applyCommentOverrides').mockResolvedValue(undefined);
+
+    await service.updateBuildsAndDeploysFromCommentEdit(
+      pullRequest,
+      '- [x] Redeploy Environment\n- [x] Purge Fastly Service Cache'
+    );
+
+    expect(enqueueResolveAndDeployBuild).toHaveBeenCalledTimes(1);
+    expect(purge).not.toHaveBeenCalled();
   });
 
   it('does not redeploy when no redeploy checkbox is ticked', async () => {

--- a/src/server/services/__tests__/activityStream.test.ts
+++ b/src/server/services/__tests__/activityStream.test.ts
@@ -307,3 +307,57 @@ describe('ActivityStream comment overrides', () => {
     expect(block).not.toContain('undefined');
   });
 });
+
+describe('ActivityStream comment edit ordering', () => {
+  function createCommentEditFixture() {
+    const service = createActivityStream();
+    const enqueueResolveAndDeployBuild = jest.fn().mockResolvedValue(undefined);
+    (service as any).db.services.BuildService = { enqueueResolveAndDeployBuild };
+    jest.spyOn(service as any, 'updatePullRequestActivityStream').mockResolvedValue(undefined);
+
+    const pullRequest = {
+      $fetchGraph: jest.fn().mockResolvedValue(undefined),
+      build: { id: 42, uuid: 'current-build', deploys: [] },
+      repository: {},
+    } as any;
+
+    return { service, pullRequest, enqueueResolveAndDeployBuild };
+  }
+
+  it('applies overrides before the redeploy and shares one run uuid', async () => {
+    const { service, pullRequest, enqueueResolveAndDeployBuild } = createCommentEditFixture();
+    const calls: string[] = [];
+    const applyCommentOverrides = jest.spyOn(service as any, 'applyCommentOverrides').mockImplementation(async () => {
+      calls.push('overrides');
+    });
+    enqueueResolveAndDeployBuild.mockImplementation(async () => {
+      calls.push('redeploy');
+    });
+
+    await service.updateBuildsAndDeploysFromCommentEdit(pullRequest, '- [x] Redeploy Environment');
+
+    expect(calls).toEqual(['overrides', 'redeploy']);
+    expect(enqueueResolveAndDeployBuild).toHaveBeenCalledWith({
+      buildId: 42,
+      runUUID: applyCommentOverrides.mock.calls[0][0].runUuid,
+    });
+  });
+
+  it('still redeploys when the comment body cannot be parsed', async () => {
+    const { service, pullRequest, enqueueResolveAndDeployBuild } = createCommentEditFixture();
+    jest.spyOn(service as any, 'applyCommentOverrides').mockRejectedValue(new Error('unparseable body'));
+
+    await service.updateBuildsAndDeploysFromCommentEdit(pullRequest, '- [x] Redeploy Environment');
+
+    expect(enqueueResolveAndDeployBuild).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not redeploy when no redeploy checkbox is ticked', async () => {
+    const { service, pullRequest, enqueueResolveAndDeployBuild } = createCommentEditFixture();
+    jest.spyOn(service as any, 'applyCommentOverrides').mockResolvedValue(undefined);
+
+    await service.updateBuildsAndDeploysFromCommentEdit(pullRequest, '- [ ] Redeploy Environment');
+
+    expect(enqueueResolveAndDeployBuild).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/override.test.ts
+++ b/src/server/services/__tests__/override.test.ts
@@ -214,6 +214,31 @@ describe('OverrideService.applyBuildOverrides', () => {
     });
   });
 
+  it('leaves trackDefaultBranches untouched when the comment has no option line', async () => {
+    const { service } = createService();
+    const args = createFullYamlArgs({ redeployOnPush: undefined });
+
+    await service.applyBuildOverrides(args);
+
+    expect(args.build.$query().patch).toHaveBeenCalledWith({
+      commentInitEnv: {
+        FEATURE_ENABLED: 'true',
+      },
+      commentRuntimeEnv: {
+        FEATURE_ENABLED: 'true',
+      },
+    });
+  });
+
+  it('persists an unchecked option line as false', async () => {
+    const { service } = createService();
+    const args = createFullYamlArgs({ redeployOnPush: false });
+
+    await service.applyBuildOverrides(args);
+
+    expect(args.build.$query().patch).toHaveBeenCalledWith(expect.objectContaining({ trackDefaultBranches: false }));
+  });
+
   it('patches unchecked services as inactive while preserving branch override behavior', async () => {
     const { service } = createService();
     const args = createFullYamlArgs({

--- a/src/server/services/__tests__/override.test.ts
+++ b/src/server/services/__tests__/override.test.ts
@@ -220,14 +220,8 @@ describe('OverrideService.applyBuildOverrides', () => {
 
     await service.applyBuildOverrides(args);
 
-    expect(args.build.$query().patch).toHaveBeenCalledWith({
-      commentInitEnv: {
-        FEATURE_ENABLED: 'true',
-      },
-      commentRuntimeEnv: {
-        FEATURE_ENABLED: 'true',
-      },
-    });
+    const patchArg = (args.build.$query().patch as jest.Mock).mock.calls[0][0];
+    expect(patchArg).not.toHaveProperty('trackDefaultBranches');
   });
 
   it('persists an unchecked option line as false', async () => {

--- a/src/server/services/activityStream.ts
+++ b/src/server/services/activityStream.ts
@@ -145,7 +145,8 @@ export default class ActivityStream extends BaseService {
       const isFastlyPurgeRequested = commentBody.includes(PURGE_FASTLY_CHECKBOX);
 
       try {
-        if (isFastlyPurgeRequested) {
+        // A redeploy request still takes precedence over a purge, as it did before overrides moved first.
+        if (isFastlyPurgeRequested && !isRedeployRequested) {
           // if fastly purge is requested from comment, we do not have to update the status
           await this.purgeFastlyServiceCache(buildUuid);
           shouldUpdateStatus = false;
@@ -469,7 +470,7 @@ export default class ActivityStream extends BaseService {
       }
     }
 
-    if (build.status !== BuildStatus.TORN_DOWN && build.status !== BuildStatus.TEARING_DOWN) {
+    if (build.status !== BuildStatus.TORN_DOWN) {
       message += '### Options\n*(Toggle options by clicking the checkboxes)*\n';
       message += `- [${build.trackDefaultBranches ? 'x' : ' '}] Redeploy on pushes to default branches\n\n`;
     }

--- a/src/server/services/activityStream.ts
+++ b/src/server/services/activityStream.ts
@@ -145,15 +145,6 @@ export default class ActivityStream extends BaseService {
       const isFastlyPurgeRequested = commentBody.includes(PURGE_FASTLY_CHECKBOX);
 
       try {
-        if (isRedeployRequested) {
-          getLogger().info('Deploy: redeploy reason=commentEdit');
-          await this.db.services.BuildService.enqueueResolveAndDeployBuild({
-            buildId,
-            runUUID: runUuid,
-          });
-          return;
-        }
-
         if (isFastlyPurgeRequested) {
           // if fastly purge is requested from comment, we do not have to update the status
           await this.purgeFastlyServiceCache(buildUuid);
@@ -162,7 +153,20 @@ export default class ActivityStream extends BaseService {
         }
 
         // handle all environment/service overrides
-        await this.applyCommentOverrides({ build, deploys, pullRequest, commentBody, runUuid });
+        // Applied before the redeploy so a single edit that changes options and ticks Redeploy keeps both,
+        // and a body we cannot parse still lets the redeploy through.
+        await this.applyCommentOverrides({ build, deploys, pullRequest, commentBody, runUuid }).catch((error) => {
+          getLogger().error({ error }, 'Comment: override apply failed');
+        });
+
+        if (isRedeployRequested) {
+          getLogger().info('Deploy: redeploy reason=commentEdit');
+          // Same runUuid as the override path, so the two enqueues collapse into one deployment.
+          await this.db.services.BuildService.enqueueResolveAndDeployBuild({
+            buildId,
+            runUUID: runUuid,
+          });
+        }
       } finally {
         // after everything update the pr comment
         await this.updatePullRequestActivityStream(
@@ -465,9 +469,9 @@ export default class ActivityStream extends BaseService {
       }
     }
 
-    if (build.trackDefaultBranches) {
+    if (build.status !== BuildStatus.TORN_DOWN && build.status !== BuildStatus.TEARING_DOWN) {
       message += '### Options\n*(Toggle options by clicking the checkboxes)*\n';
-      message += `- [x] Redeploy on pushes to default branches\n\n`;
+      message += `- [${build.trackDefaultBranches ? 'x' : ' '}] Redeploy on pushes to default branches\n\n`;
     }
 
     return message;

--- a/src/server/services/activityStream.ts
+++ b/src/server/services/activityStream.ts
@@ -153,9 +153,7 @@ export default class ActivityStream extends BaseService {
           return;
         }
 
-        // handle all environment/service overrides
-        // Applied before the redeploy so a single edit that changes options and ticks Redeploy keeps both,
-        // and a body we cannot parse still lets the redeploy through.
+        // Runs first so one edit can change options and redeploy, and a bad body still redeploys.
         await this.applyCommentOverrides({ build, deploys, pullRequest, commentBody, runUuid }).catch((error) => {
           getLogger().error({ error }, 'Comment: override apply failed');
         });

--- a/src/server/services/override.ts
+++ b/src/server/services/override.ts
@@ -46,7 +46,8 @@ export interface BuildOverrideInput {
   serviceOverrides: ServiceOverrideInput[];
   vanityUrl: string | null;
   envOverrides: Record<string, any>;
-  redeployOnPush: boolean;
+  /** Undefined when the comment has no option line; the stored value is then left untouched. */
+  redeployOnPush?: boolean;
 }
 
 export interface BuildConfigPatchInput {
@@ -201,7 +202,7 @@ export default class OverrideService extends BaseService {
     await build.$query().patch({
       commentInitEnv: overrides.envOverrides,
       commentRuntimeEnv: overrides.envOverrides,
-      trackDefaultBranches: overrides.redeployOnPush,
+      ...(overrides.redeployOnPush === undefined ? {} : { trackDefaultBranches: overrides.redeployOnPush }),
     });
 
     getLogger().debug(`Service overrides: ${JSON.stringify(overrides.serviceOverrides)}`);

--- a/src/shared/openApiSpec.test.ts
+++ b/src/shared/openApiSpec.test.ts
@@ -352,6 +352,9 @@ describe('OpenAPI v2 agent session contract', () => {
         additionalProperties: true,
       })
     );
+    expect(schemas.Build.properties.trackDefaultBranches).toEqual({ type: 'boolean', example: false });
+    // The column is nullable, so requiring it would make the spec lie about degraded responses.
+    expect(schemas.Build.required).not.toContain('trackDefaultBranches');
     expect(schemas.UpdateBuildServiceOverrideRequest).toBeUndefined();
     expect(schemas.UpdateBuildEnvironmentOverridesRequest).toBeUndefined();
     expect(schemas.UpdateBuildOptionsRequest).toBeUndefined();

--- a/src/shared/openApiSpec.ts
+++ b/src/shared/openApiSpec.ts
@@ -4696,6 +4696,7 @@ export const openApiSpecificationForV2Api: OAS3Options = {
             kind: { $ref: '#/components/schemas/BuildKind' },
             namespace: { type: 'string', example: 'env-white-poetry-596195' },
             isStatic: { type: 'boolean', example: false },
+            trackDefaultBranches: { type: 'boolean', example: false },
             baseBuildId: { type: 'integer', nullable: true },
             commentRuntimeEnv: {
               type: 'object',


### PR DESCRIPTION
## What

The **Redeploy on pushes to default branches** option now appears as a checkbox in the environment comment for every active environment.

Previously it was only rendered once already enabled, so it could be switched off from the comment but never on. In practice that meant it could only be set from the CLI.

## Behaviour

- The option applies only to services with no branch override. A service pinned to a branch already rebuilds on pushes to that branch, and is unaffected.
- Setting it queues a redeploy, as it did before.
- The option is hidden once an environment is torn down.
- A comment that does not contain the option is left alone rather than treated as a request to disable it.

## Also

`trackDefaultBranches` is added to the build API schema. The endpoint already returned it; only the schema was missing it, so clients could not type it.

## Testing

Parser coverage for the checked, unchecked and absent cases, and for bodies that should not match. Ordering coverage for comment edits that request several things at once.