### PR TITLE
fix: allow any session to read sites config

### DIFF
--- a/src/app/api/v2/config/sites/route.test.ts
+++ b/src/app/api/v2/config/sites/route.test.ts
@@ -77,7 +77,7 @@ describe('/api/v2/config/sites', () => {
     }
   });
 
-  it('requires admin access before reading config', async () => {
+  it('allows any session to read config', async () => {
     mockGetUser.mockReturnValue({
       sub: 'sample-user',
       realm_access: {
@@ -88,9 +88,28 @@ describe('/api/v2/config/sites', () => {
     const response = await GET(makeRequest());
     const body = await response.json();
 
+    expect(response.status).toBe(200);
+    expect(body.data.config).toMatchObject({
+      enabled: false,
+      domain: 'localhost',
+      hostPrefix: 'site',
+    });
+  });
+
+  it('requires admin access before updating config', async () => {
+    mockGetUser.mockReturnValue({
+      sub: 'sample-user',
+      realm_access: {
+        roles: ['user'],
+      },
+    });
+
+    const response = await PUT(makeRequest({ enabled: true }));
+    const body = await response.json();
+
     expect(response.status).toBe(403);
     expect(body.error.message).toBe('Forbidden: insufficient permissions');
-    expect(mockGetSitesConfig).not.toHaveBeenCalled();
+    expect(mockSetSitesConfig).not.toHaveBeenCalled();
   });
 
   it('returns the Sites config', async () => {

--- a/src/app/api/v2/config/sites/route.ts
+++ b/src/app/api/v2/config/sites/route.ts
@@ -44,12 +44,6 @@ import type { SitesConfig } from 'server/services/types/globalConfig';
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ApiErrorResponse'
- *       '403':
- *         description: Forbidden
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
  *   put:
  *     summary: Update Sites configuration
  *     description: Replaces the global Sites hosting configuration stored in global_config under the sites key.
@@ -112,5 +106,5 @@ const putHandler = async (req: NextRequest) => {
   return successResponse({ config }, { status: 200 }, req);
 };
 
-export const GET = createApiHandler(getHandler, { auth: 'session', roles: ['admin'] });
+export const GET = createApiHandler(getHandler, { auth: 'session' });
 export const PUT = createApiHandler(putHandler, { auth: 'session', roles: ['admin'] });

--- a/src/server/lib/v2RoutePolicyManifest.ts
+++ b/src/server/lib/v2RoutePolicyManifest.ts
@@ -230,7 +230,7 @@ export const V2_ROUTE_POLICY_MANIFEST: readonly V2RoutePolicyEntry[] = [
     policy: 'session',
     roles: ['admin'],
   },
-  { method: 'GET', route: '/api/v2/config/sites', policy: 'session', roles: ['admin'] },
+  { method: 'GET', route: '/api/v2/config/sites', policy: 'session' },
   { method: 'PUT', route: '/api/v2/config/sites', policy: 'session', roles: ['admin'] },
   { method: 'GET', route: '/api/v2/environments', policy: 'principal', scope: 'env:read' },
   { method: 'POST', route: '/api/v2/environments', policy: 'principal', scope: 'env:write' },


### PR DESCRIPTION
## Summary
Reading the Sites hosting config required an admin role, even though non-sensitive fields (like whether Sites is enabled) are needed by any signed-in user's session. Non-admin users were getting a permissions error just from viewing the Sites page.

## Change
- `GET /api/v2/config/sites` now allows any authenticated session.
- `PUT /api/v2/config/sites` still requires the admin role, unchanged.

## Testing
- Updated and passed the route's unit tests.
- Lint and typecheck pass on the changed files.
